### PR TITLE
Standardize dev vault deployment and use recommended openshift images

### DIFF
--- a/common/install/templates/argocd/subscription.yaml
+++ b/common/install/templates/argocd/subscription.yaml
@@ -12,6 +12,10 @@ spec:
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  config:
+    env:
+      - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+        value: {{ .Release.Name }}-{{ .Values.main.clusterGroupName }},openshift-gitops
 {{- if .Values.main.options.useCSV }}
   startingCSV: openshift-gitops-operator.{{ .Values.main.gitops.csv }}
 {{- end }}

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -8,6 +8,21 @@ server:
   dev:
     enabled: true
 
+  # Values from values.openshift.yaml in common/vault to work better with openshift
+  image:
+    repository: "registry.connect.redhat.com/hashicorp/vault"
+    tag: "1.9.0-ubi"
+
+# Values from values.openshift.yaml in common/vault to work better with openshift
+injector:
+  image:
+    repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
+    tag: "0.14.1-ubi"
+
+  agentImage:
+    repository: "registry.connect.redhat.com/hashicorp/vault"
+    tag: "1.9.0-ubi"
+
 clusterGroup:
   name: hub
 


### PR DESCRIPTION
Add some new values to values-hub.yaml from the common/vault/values.openshift.yaml that should improve the installation experience.  (Initial installs of vault on OCP 4.8.4 seemed to not be defaulting to docker.io as the registry to pull images from, and the images there were not ubi-based).

The values file included in the helm chart was designed to be included as a command-line override, so we copy the values out of it into values-hub.yaml so those overrides will be visible to hub applications.