### PR TITLE
Remove vault-route app and update vault-helm to v0.19.0

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -34,7 +34,7 @@ clusterGroup:
     project: hub
     chart: vault
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: v0.18.0
+    targetRevision: v0.19.0
     overrides:
     - name: global.openshift
       value: "true"
@@ -42,23 +42,24 @@ clusterGroup:
       value: "true"
     - name: ui.serviceType
       value: LoadBalancer
+    - name: server.route.enabled
+      value: "true"
+    - name: server.route.host
+      value: null
+    - name: server.route.tls.termination
+      value: edge
     - name: server.image.repository
       value: "registry.connect.redhat.com/hashicorp/vault"
     - name: server.image.tag
-      value: "1.9.0-ubi"
+      value: "1.9.2-ubi"
     - name: injector.image.repository
       value: "registry.connect.redhat.com/hashicorp/vault-k8s"
     - name: injector.image.tag
-      value: "0.14.1-ubi"
+      value: "0.14.2-ubi"
     - name: injector.agentImage.repository
       value: "registry.connect.redhat.com/hashicorp/vault"
     - name: injector.agentImage.tag
-      value: "1.9.0-ubi"
-
-  - name: vault-route
-    namespace: vault
-    project: hub
-    path: common/vault-route
+      value: "1.9.2-ubi"
 
   managedClusterGroups:
   - name: region-one


### PR DESCRIPTION
With vault-helm v0.19.0 we can create the route with edge termination,
so the vault-route app is not needed any longer.
While we're at it we update the container images to the versions defined
in the new release (see vault-helm b0528fce49c529f2c37953ea3a14f30ed651e0d6)

Tested this and got a correctly exposed route:

  $ oc get route vault -n vault -o yaml | oc neat
  apiVersion: route.openshift.io/v1
  kind: Route
  metadata:
    annotations:
      openshift.io/host.generated: "true"
    labels:
      app.kubernetes.io/instance: vault
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: vault
      argocd.argoproj.io/instance: vault
      helm.sh/chart: vault-0.19.0
    name: vault
    namespace: vault
  spec:
    host: vault-vault.apps.test.lab.local
    port:
      targetPort: 8200
    tls:
      termination: edge
    to:
      kind: Service
      name: vault
      weight: 100
    wildcardPolicy: None
