### PR TITLE
Add k8s-external-secrets regional application

### DIFF
--- a/charts/region/k8s-external-secrets/Chart.yaml
+++ b/charts/region/k8s-external-secrets/Chart.yaml
@@ -6,5 +6,5 @@ name: k8s-external-secrets
 version: 0.0.1
 dependencies:
   - name: kubernetes-external-secrets
-    version: "8.5.1"
+    version: "8.5.2"
     repository: "https://external-secrets.github.io/kubernetes-external-secrets"

--- a/charts/region/k8s-external-secrets/Chart.yaml
+++ b/charts/region/k8s-external-secrets/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: A Helm chart to configure kubernetes-external-secrets on regional clusters
+keywords:
+- pattern
+name: k8s-external-secrets
+version: 0.0.1
+dependencies:
+  - name: kubernetes-external-secrets
+    version: "8.5.1"
+    repository: "https://external-secrets.github.io/kubernetes-external-secrets"

--- a/charts/region/k8s-external-secrets/templates/kubernetes-external-secrets-clusterbinding.yaml
+++ b/charts/region/k8s-external-secrets/templates/kubernetes-external-secrets-clusterbinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-external-secrets
+  namespace: kubernetes-external-secrets

--- a/charts/region/k8s-external-secrets/templates/kubernetes-external-secrets-vault-cm.yaml
+++ b/charts/region/k8s-external-secrets/templates/kubernetes-external-secrets-vault-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-external-secrets-vault-cm
+data:
+  VAULT_ADDR: https://vault-vault.{{ .Values.global.hubClusterDomain }}
+  NODE_EXTRA_CA_CERTS: "/usr/local/share/ca-certificates/ca.crt"

--- a/charts/region/k8s-external-secrets/values.yaml
+++ b/charts/region/k8s-external-secrets/values.yaml
@@ -1,0 +1,23 @@
+---
+# Values passed to the subchart dependency. Note that we *have* to use envVarsFromConfigMap
+# for the following reasons:
+# 1. We cannot override env.VAULT_ADDR because values.yaml does not get rendered
+#    (so we get {{ .Values.global.hubClusterDomain }} and not the rendered value)
+# 2. Using envFrom won't work because the helm chart has VAULT_ADDR set to a default and it
+#    will win when a container has both envFrom and env variables set
+# With this method we get the correct value.
+kubernetes-external-secrets:
+  envVarsFromConfigMap:
+    VAULT_ADDR:
+      configMapKeyRef: kubernetes-external-secrets-vault-cm
+      key: VAULT_ADDR
+    NODE_EXTRA_CA_CERTS:
+      configMapKeyRef: kubernetes-external-secrets-vault-cm
+      key: NODE_EXTRA_CA_CERTS
+
+# Note: Until there is a secret called vault-ca in the k8s-external-secrets NS the pod
+# will not be healthy
+  filesFromSecret:
+    certificate-authority:
+      secret: vault-ca
+      mountPath: /usr/local/share/ca-certificates

--- a/common/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/common/acm/templates/policies/ocp-gitops-policy.yaml
@@ -42,6 +42,10 @@ spec:
                   name: openshift-gitops-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
+                  config:
+                    env:
+                      - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+                        value: "*"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -10,8 +10,8 @@ clusterGroup:
   subscriptions:
   - name: advanced-cluster-management
     namespace: open-cluster-management
-    channel: release-2.3
-    csv: advanced-cluster-management.v2.3.5
+    channel: release-2.4
+    csv: advanced-cluster-management.v2.4.1
 
   projects:
   - hub

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -22,6 +22,9 @@ clusterGroup:
     namespace: open-cluster-management
     project: hub
     path: common/acm
+    overrides:
+    - name: pushHubCA
+      value: True
     ignoreDifferences:
     - group: internal.open-cluster-management.io
       kind: ManagedClusterInfo

--- a/values-region-one.yaml
+++ b/values-region-one.yaml
@@ -10,13 +10,13 @@ clusterGroup:
 
   namespaces:
     - multicloud-gitops-region-one
-    - external-secrets
+    - k8s-external-secrets
     - config-demo
 
   subscriptions:
 
   projects:
-    - external-secrets
+    - k8s-external-secrets
     - config-demo
 
   applications:
@@ -25,12 +25,10 @@ clusterGroup:
     project: config-demo
     path: charts/region/config-demo
 
-#    - name: external-secrets
-#      namespace: external-secrets
-#      project: external-secrets
-#      chart: external-secrets
-#      repoURL: https://charts.external-secrets.io
-#      targetRevision: v0.3.10
+  - name: k8s-external-secrets
+    namespace: k8s-external-secrets
+    project: k8s-external-secrets
+    path: charts/region/k8s-external-secrets
 
 #
 #  To have apps in multiple flavors, use namespaces and use helm overrides as appropriate


### PR DESCRIPTION
We introduce charts/region/k8s-external-secrets which deploys the
kubernetes-external-secret chart on regional clusters pointing to the
vault installed on the hub. Note that until we create a secret called
'vault-ca' in the k8s-external-secret namespace, the operator pod will
not be healthy as a mountpoint will be missing.

This depends on https://github.com/hybrid-cloud-patterns/common/pull/37
to work.

Tested in conjunction with the common PR and I correctly am able to get
the correct VAULT_ADDR configured:

  for i in $(oc -n k8s-external-secrets get pods -o jsonpath='{range .items[*].metadata}{.name}{end}'); do
    oc exec -n k8s-external-secrets -it "$i" -- env |grep VAULT_ADDR
  done
  VAULT_ADDR=vault-vault.apps.bandini-dc.blueprints.rhecoeng.com
