### PR TITLE
Fix MBP-132, update common, and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*~
+*.swp
+*.swo
+values-secret.yaml
+.*.expected.yaml
+pattern-vault.init
+vault.init

--- a/common/acm/templates/policies/hub-certificate-authority.yaml
+++ b/common/acm/templates/policies/hub-certificate-authority.yaml
@@ -1,0 +1,78 @@
+# We only push the hub CA to the regional clusters when the user explicitely tells us so
+# This template fetches "ca.crt" from the "kube-root-ca.crt" configMap from the hub
+# (this configmap is present in all namespaces) and puts it in the vault-ca secret inside
+# the k8s-external-secrets namespace so the external-secrets pod knows how to trust
+# the https://vault-vault.apps.hub-domain... endpoint
+{{- if .Values.pushHubCA }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: hub-certificate-authority-policy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: hub-certificate-authority
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace
+                apiVersion: v1
+                metadata:
+                  name: k8s-external-secrets
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Secret
+                metadata:
+                  name: vault-ca
+                  namespace: k8s-external-secrets
+                data:
+                  ca.crt: '{{ `{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | base64enc hub}}` }}'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: hub-certificate-authority-placement-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: hub-certificate-authority-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: hub-certificate-authority-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: hub-certificate-authority-placement
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+{{- end }}

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -8,3 +8,4 @@ global:
 clusterGroup:
   managedClusterGroups:
 
+pushHubCA: false

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -35,10 +35,11 @@ clusterGroup:
     repoURL: https://helm.releases.hashicorp.com
     targetRevision: v0.19.0
     ignoreDifferences:
-    - kind: MutatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
       name: vault-agent-injector-cfg
       jsonPointers:
-        - /webhooks/clientConfig/caBundle
+        - /webhooks/0/clientConfig/caBundle
     overrides:
     - name: global.openshift
       value: "true"

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -34,6 +34,11 @@ clusterGroup:
     chart: vault
     repoURL: https://helm.releases.hashicorp.com
     targetRevision: v0.19.0
+    ignoreDifferences:
+    - kind: MutatingWebhookConfiguration
+      name: vault-agent-injector-cfg
+      jsonPointers:
+        - /webhooks/clientConfig/caBundle
     overrides:
     - name: global.openshift
       value: "true"


### PR DESCRIPTION
Add ignoreDifferences section to vault app to not mark vault-agent-injector-cfg as out of sync.
Update common with latest commits
Add .gitignore that somehow didn't exist before