### PR TITLE
Switch from rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1 in order to get things working on OCP 4.9

### DIFF
--- a/charts/region/k8s-external-secrets/templates/kubernetes-external-secrets-clusterbinding.yaml
+++ b/charts/region/k8s-external-secrets/templates/kubernetes-external-secrets-clusterbinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: role-tokenreview-binding


### PR DESCRIPTION
Otherwise we fail to sync the kubernetes-external-secret operator on the
regional cluster due to the v1beta1 deprecation.

Tested this and now things work correctly on OCP 4.9
