### PR TITLE
Add secret to config-demo

### DIFF
--- a/charts/all/config-demo/templates/config-demo-cm.yaml
+++ b/charts/all/config-demo/templates/config-demo-cm.yaml
@@ -17,5 +17,8 @@ data:
             Hub Cluster domain is '{{ .Values.global.hubClusterDomain }}' <br>
             Pod is running on Local Cluster Domain '{{ .Values.global.localClusterDomain }}' <br>
             </h1>
+            <h2>
+            The secret is <a href="/secret/secret">secret</a>
+            </h2>
           </body>
       </html>

--- a/charts/all/config-demo/templates/config-demo-deployment.yaml
+++ b/charts/all/config-demo/templates/config-demo-deployment.yaml
@@ -29,6 +29,9 @@ spec:
         volumeMounts:
         - mountPath: /var/www/html
           name: config-demo-configmap
+        - mountPath: /var/www/html/secret
+          readOnly: true
+          name: config-demo-secret
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -57,3 +60,6 @@ spec:
         configMap:
           defaultMode: 438
           name: config-demo-configmap
+      - name: config-demo-secret
+        secret:
+          secretName: config-demo-secret

--- a/charts/all/config-demo/templates/config-demo-external-secret.yaml
+++ b/charts/all/config-demo/templates/config-demo-external-secret.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.clusterGroup.isHubCluster }}
+---
+apiVersion: "external-secrets.io/v1alpha1"
+kind: ExternalSecret
+metadata:
+  name: config-demo-secret
+  namespace: config-demo
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: {{ .Values.secretStore.name }}
+    kind: {{ .Values.secretStore.kind }}
+  target:
+    name: config-demo-secret
+    template:
+      type: Opaque
+  dataFrom:
+    - key: {{ .Values.configdemosecret.key }}
+{{ end }}

--- a/charts/all/config-demo/templates/config-demo-secret.yaml
+++ b/charts/all/config-demo/templates/config-demo-secret.yaml
@@ -1,0 +1,69 @@
+# The policy needs to be added to the ACM HUB and then it will be pushed on all clusters
+# except the HUB (see placementrule on the bottom)
+{{ if .Values.clusterGroup.isHubCluster }}
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: configdemo-region-secret-policy
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: config-demo-secret
+          annotations:
+            apps.open-cluster-management.io/deployables: "secret"
+            policy.open-cluster-management.io/trigger-update: "2"
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Secret
+                type: Opaque
+                metadata:
+                  name: config-demo-secret
+                  namespace: config-demo
+                apiVersion: v1
+                data:
+                  secret: '{{ `{{hub (lookup "v1" "Secret" "config-demo" "config-demo-secret").data.secret hub}}` }}'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: configdemo-region-secret-placement-binding
+placementRef:
+  name: configdemo-region-secret-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: configdemo-region-secret-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: configdemo-region-secret-placement
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+{{ end }}

--- a/charts/all/config-demo/values.yaml
+++ b/charts/all/config-demo/values.yaml
@@ -1,1 +1,7 @@
 ---
+secretStore:
+  name: vault-backend
+  kind: ClusterSecretStore
+
+configdemosecret:
+  key: secret/data/hub/config-demo


### PR DESCRIPTION
This set adds a secret inside the config-demo app.

The secret can be injected either manually in the vault container via:
  vault kv put secret/hub/config-demo secret=bar

Or one can create ~/values-secret.yaml:
secrets:
  config-demo:
    secret: test123

And then run ./common/scripts/ansible-push-vault-secrets.sh

Due to https://issues.redhat.com/browse/ACM-1208 one will have to
tweak the policy annotation in order to have ACM refresh the
policy/secret:
  oc edit -n <remote-acm-cluster-name> policy/config-demo.configdemo-region-secret-policy

To do so automatically one can run:

  oc patch policy -n <remote-acm-cluster-name> config-demo.configdemo-region-secret-policy --type json \
    -p "[{'op': 'replace', 'path': '/spec/policy-templates/0/objectDefinition/metadata/annotations/policy.open-cluster-management.io~1trigger-update', 'value': $(date +%s)}]"

Note that Argo will eventually reconcile the above change so this is
somewhat racy.
