### PR TITLE
Update common/

### DIFF
--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -25,7 +25,7 @@ spec:
             include:
               - default
           object-templates:
-            - complianceType: musthave
+            - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1alpha1
                 kind: Application

--- a/common/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/common/acm/templates/policies/ocp-gitops-policy.yaml
@@ -26,7 +26,7 @@ spec:
             include:
               - default
           object-templates:
-            - complianceType: musthave
+            - complianceType: mustonlyhave
               objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -73,7 +73,7 @@ spec:
             include:
               - default
           object-templates:
-            - complianceType: musthave
+            - complianceType: mustonlyhave
               objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -105,7 +105,7 @@ spec:
             include:
               - default
           object-templates:
-            - complianceType: musthave
+            - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1alpha1
                 kind: Application
@@ -187,7 +187,7 @@ spec:
             include:
               - default
           object-templates:
-            - complianceType: musthave
+            - complianceType: mustonlyhave
               objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
As somewhat specified in [1] there are different complianceTypes and
'musthave' does not imply that the object being applied is *identical*
to what is specified in the policy. Namely the docs for 'musthave' state:

  "The other fields in the template are a subset of what exists in the object."

The actual consequence on real deployment of 'musthave' is the
following:
* Existing object
- foo
  bar:
  - a
  - b

If the above template gets changed in ACM:
- foo
  bar:
  - d
  - e

The end result in case of 'musthave' complianceType will be:
- foo
  bar:
  - a
  - b
  - d
  - e

So let's switch to complianceType 'mustonlyhave' which actually
enforces the full object:

  Indicates that an object must exist with the exact name and relevant fields.

Tested this on my multicloud environment and I could observe that
changes to the ACM policy templates started properly replacing objects
on the remote clusters.

[1] https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html-single/governance/index#configuration-policy-yaml-table

Closes: MBP-199
