### PR TITLE
Remove the BOOTSTRAP variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-BOOTSTRAP=1
-
 .PHONY: default
 default: help
 


### PR DESCRIPTION
Following the same removal from common/. In this pattern it's not used
at all ever, so let's drop it.
