### PR TITLE
Remove duplicate namespace on regional cluster

### DIFF
--- a/values-region-one.yaml
+++ b/values-region-one.yaml
@@ -9,7 +9,6 @@ clusterGroup:
   isHubCluster: false
 
   namespaces:
-    - multicloud-gitops-region-one
     - config-demo
 
   subscriptions:


### PR DESCRIPTION
Ilkka reported that the main argo instance on regional clusters complains about:

  Resource /Namespace//multicloud-gitops-region-one appeared 2 times among application resources.

This is because we create the multicloud-gitops-region-one namespace
twice:

A) Via common/clustergroup/templates/namespaces.yaml which renders all
the namespaces defined in values-region-one.yaml

B) Via common/clustergroup/templates/gitops-namespace.yaml which renders
the gitops namespace directly.

Let's drop A) since it is really not managed by argo in this case.

Tested this and I can correctly observe that the warning is gone.
