### PR TITLE
Remove useless exclude: kube-* from ACM policies

### DIFF
--- a/charts/all/config-demo/templates/config-demo-secret.yaml
+++ b/charts/all/config-demo/templates/config-demo-secret.yaml
@@ -25,8 +25,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/tests/all-config-demo-naked.expected.yaml
+++ b/tests/all-config-demo-naked.expected.yaml
@@ -202,8 +202,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/tests/all-config-demo-normal.expected.yaml
+++ b/tests/all-config-demo-normal.expected.yaml
@@ -202,8 +202,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:


### PR DESCRIPTION
The namespaceSelector example:

  namespaceSelector:
    include: ["default"]
    exclude: ["kube-*"]

shows up in many places in the documentation. Yet it is not particularly
relevant. Full explanation can be found in
https://bugzilla.redhat.com/show_bug.cgi?id=2079393

Let's just drop the exclude, since we already define an include
without a regex, there is no point in excluding anything really.

Tested by redeploying a full multicloud-gitops pattern across
two clusters.
