### PR TITLE
Rename severity in ACM policies

### DIFF
--- a/charts/all/config-demo/templates/config-demo-secret.yaml
+++ b/charts/all/config-demo/templates/config-demo-secret.yaml
@@ -23,7 +23,7 @@ spec:
             policy.open-cluster-management.io/trigger-update: "2"
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default

--- a/tests/all-config-demo-naked.expected.yaml
+++ b/tests/all-config-demo-naked.expected.yaml
@@ -200,7 +200,7 @@ spec:
             policy.open-cluster-management.io/trigger-update: "2"
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default

--- a/tests/all-config-demo-normal.expected.yaml
+++ b/tests/all-config-demo-normal.expected.yaml
@@ -200,7 +200,7 @@ spec:
             policy.open-cluster-management.io/trigger-update: "2"
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default


### PR DESCRIPTION
Use 'medium' instead of 'med' as ACM 2.5 complains.
Whereas 'medium' is accepted by any ACM version.
Likely we just cargo-culted this value at some point in time.
