### PR TITLE
Move golang-external-secrets in the hub Argo project

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -18,7 +18,6 @@ clusterGroup:
   projects:
   - hub
   - config-demo
-  - golang-external-secrets
 
   applications:
     acm:
@@ -62,7 +61,7 @@ clusterGroup:
     golang-external-secrets:
       name: golang-external-secrets
       namespace: golang-external-secrets
-      project: golang-external-secrets
+      project: hub
       path: common/golang-external-secrets
 
     config-demo:


### PR DESCRIPTION
We do not need a separate project for this app and it makes
sense to group it with acm and vault

Tested and everything deployed correctly on the hub.
