### PR TITLE
Update common with ESO 0.5.6 and move to betav1 externalsecrets

### DIFF
--- a/charts/all/config-demo/templates/config-demo-external-secret.yaml
+++ b/charts/all/config-demo/templates/config-demo-external-secret.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.clusterGroup.isHubCluster }}
 ---
-apiVersion: "external-secrets.io/v1alpha1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: config-demo-secret
@@ -15,5 +15,6 @@ spec:
     template:
       type: Opaque
   dataFrom:
-    - key: {{ .Values.configdemosecret.key }}
+  - extract:
+      key: {{ .Values.configdemosecret.key }}
 {{ end }}

--- a/tests/all-config-demo-naked.expected.yaml
+++ b/tests/all-config-demo-naked.expected.yaml
@@ -186,7 +186,7 @@ spec:
 # except the HUB (see placementrule on the bottom)
 ---
 # Source: config-demo/templates/config-demo-external-secret.yaml
-apiVersion: "external-secrets.io/v1alpha1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: config-demo-secret
@@ -201,7 +201,8 @@ spec:
     template:
       type: Opaque
   dataFrom:
-    - key: secret/data/hub/config-demo
+  - extract:
+      key: secret/data/hub/config-demo
 ---
 # Source: config-demo/templates/config-demo-is.yaml
 apiVersion: image.openshift.io/v1

--- a/tests/all-config-demo-normal.expected.yaml
+++ b/tests/all-config-demo-normal.expected.yaml
@@ -186,7 +186,7 @@ spec:
 # except the HUB (see placementrule on the bottom)
 ---
 # Source: config-demo/templates/config-demo-external-secret.yaml
-apiVersion: "external-secrets.io/v1alpha1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: config-demo-secret
@@ -201,7 +201,8 @@ spec:
     template:
       type: Opaque
   dataFrom:
-    - key: secret/data/hub/config-demo
+  - extract:
+      key: secret/data/hub/config-demo
 ---
 # Source: config-demo/templates/config-demo-is.yaml
 apiVersion: image.openshift.io/v1

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -37,7 +37,7 @@ clusterGroup:
       project: hub
       chart: vault
       repoURL: https://helm.releases.hashicorp.com
-      targetRevision: v0.20.0
+      targetRevision: v0.20.1
       overrides:
       - name: global.openshift
         value: "true"


### PR DESCRIPTION
- Update external-secrets to 0.5.6
- Move to beta1 for external-secret
- Update vault-helm to 0.20.1
