### PR TITLE
Add super linter

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,38 @@
+---
+name: Super linter
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # Name the Job
+    name: Super linter
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # These are the validation we disable atm
+          VALIDATE_BASH: false
+          VALIDATE_JSCPD: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
+          VALIDATE_YAML: false
+          VALIDATE_ANSIBLE: false
+          # VALIDATE_DOCKERFILE_HADOLINT: false
+          # VALIDATE_MARKDOWN: false
+          # VALIDATE_NATURAL_LANGUAGE: false
+          # VALIDATE_TEKTON: false

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,12 @@ helmlint:
 kubeconform:
 	make -f common/Makefile CHARTS="$(wildcard charts/all/*)" kubeconform
 	make -f common/Makefile CHARTS="$(wildcard charts/hub/*)" kubeconform
+
+super-linter: ## Runs super linter locally
+	podman run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true	\
+					-e VALIDATE_BASH=false \
+					-e VALIDATE_JSCPD=false \
+					-e VALIDATE_KUBERNETES_KUBEVAL=false \
+					-e VALIDATE_YAML=false \
+					-e VALIDATE_ANSIBLE=false \
+					-v $(PWD):/tmp/lint:rw,z docker.io/github/super-linter:slim-v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Start Here
 
 If you've followed a link to this repo, but are not really sure what it contains
-or how to use it, head over to http://hybrid-cloud-patterns.io/multicloud-gitops/
+or how to use it, head over to [Multicloud GitOps](http://hybrid-cloud-patterns.io/multicloud-gitops/)
 for additional context and installation instructions

--- a/ansible/playbooks/on-hub-get-regional-ca.yml
+++ b/ansible/playbooks/on-hub-get-regional-ca.yml
@@ -19,7 +19,7 @@
         resources: "{{ managed_clusters['resources'] }}"
 
     - name: Do nothing when no managed clusters are found
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: resources | length == 0 or managed_clusters.failed or not managed_clusters.api_found
 
     - name: Loop over returned managed cluster resources
@@ -40,4 +40,3 @@
       loop: "{{ resources }}"
       loop_control:
         label: "{{ item.metadata.name }}"
-

--- a/ansible/playbooks/on-regional-get-hub-ca.yml
+++ b/ansible/playbooks/on-regional-get-hub-ca.yml
@@ -16,7 +16,7 @@
       register: hub_cluster
 
     - name: Do nothing when no managed clusters are found
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: hub_cluster.resources | length == 0 or hub_cluster.failed or not hub_cluster.api_found
 
     - name: Set resource fact
@@ -24,7 +24,7 @@
         resource: "{{ hub_cluster['resources'][0] }}"
 
     - name: Do nothing when no kubeconfig is not present yet
-      meta: end_play
+      ansible.builtin.meta: end_play
       when:
         - "'data' not in resource"
         - "'kubeconfig' not in resource.data"
@@ -44,7 +44,7 @@
         hub_cluster_kubeconfig: "{{ resource.data.kubeconfig | b64decode | from_yaml }}"
 
     - name: Set CA fact
-      set_fact:
+      ansible.builtin.set_fact:
         # The .get() call is needed because the key has dashes in it
         hub_cluster_ca: "{{ hub_cluster_kubeconfig.clusters[0].cluster.get('certificate-authority-data') }}"
 

--- a/ansible/roles/bootstrap/README.md
+++ b/ansible/roles/bootstrap/README.md
@@ -1,19 +1,16 @@
 # Ansible Role: bootstrap
-=========
 
 This is the bootstrap role to deploy the MultiCloud-GitOps pattern.  This role contains all the imperative tasks that are needed to deploy the MultiCloud-GitOps validated pattern onto an OpenShift cluster.
-The main purpose of this role is for RHPDS to deploy this pattern by calling our ansible/site.yaml playbook which in turn calls our bootstrap role.  In the same vein a user can execute the following from the command line to deploy
+The main purpose of this role is for RHPDS to deploy this pattern by calling our ansible/site.yaml playbook which in turn calls our bootstrap role.  In the same vein a user can execute the following from the command-line to deploy
 the validated pattern:
 
 $ ansible-playbook ansible/site.yaml
 
-
 ## Requirements
-------------
 
 * Pre-deployed Openshift or Kubernetes Cluster
 * Must be Cluster Admin to successfully execute this role.
-* There are a few tools that you will need to run this role which are listed below.  
+* There are a few tools that you will need to run this role which are listed below.
 
 | Tool | Description | Download link |
 | ----------- | ----------- | ----------- |
@@ -22,29 +19,31 @@ $ ansible-playbook ansible/site.yaml
 | Python 3 | Python2 is deprecated from 1st January 2020. Please switch to Python3. | RHEL: <br> **yum -y install rh-python36** |
 
 ## Bootstrap Role tasks that will be executed
+
 The bootstrap-industrial-edge role will execute on your localhost.  The high level tasks that are executed are listed below.
 
 ```sh
 playbook: ansible/site.yaml
 
-  play #1 (localhost): MultiCloud-GitOps bootstrap	TAGS: []
+  play #1 (localhost): MultiCloud-GitOps bootstrap  TAGS: []
     tasks:
-      bootstrap : {{ role_name }}: Getting pattern information	TAGS: []
-      bootstrap : {{ role_name }}: debug	TAGS: []
-      bootstrap : {{ role_name }}: Deploying Helm Charts	TAGS: []
-      bootstrap : {{ role_name }}: Initialize Vault	TAGS: []
-      bootstrap : {{ role_name }}: Load Secrets to Vault	TAGS: []
+      bootstrap : {{ role_name }}: Getting pattern information  TAGS: []
+      bootstrap : {{ role_name }}: debug  TAGS: []
+      bootstrap : {{ role_name }}: Deploying Helm Charts  TAGS: []
+      bootstrap : {{ role_name }}: Initialize Vault  TAGS: []
+      bootstrap : {{ role_name }}: Load Secrets to Vault  TAGS: []
 ```
 
 ### Task: Getting pattern information
 
 This task gathers the validated pattern information.  This information will be used by the validated pattern framework and passed to ArgoCD to support the validated pattern deployment.  The task sets up the following facts for other tasks to use:
-    * secrets_file                                                         
-    * globals_file                                                              
-    * bootstrap
-    * target_branch
-    * target_repo
-    * hubcluster_apps_domain
+
+* secrets_file
+* globals_file
+* bootstrap
+* target_branch
+* target_repo
+* hubcluster_apps_domain
 
 ### Task: Deploying Helm Charts
 
@@ -52,8 +51,7 @@ Our validated pattern framework makes use of Helm Charts to deploy supporting co
 
 | Chart | Description | Location |
 | ----- | ----- | ----- |
-| multicloud-gitops | A Helm chart to build and deploy the validated pattern | multicloud-gitops/common/install | 
-
+| multicloud-gitops | A Helm chart to build and deploy the validated pattern | multicloud-gitops/common/install |
 
 ### Task: Initialize Vault
 
@@ -63,10 +61,9 @@ This task initializes the Vault environment.
 
 ### Task: Load Secrets to Vault
 
-The MultiCloud-GitOps validated pattern application makes use of secrets that are stored in the Vault environment.  This task is an imperative task that loads the secrets defined in the values-secret.yaml file which are specific to the Validated Pattern application workloads. 
+The MultiCloud-GitOps validated pattern application makes use of secrets that are stored in the Vault environment.  This task is an imperative task that loads the secrets defined in the values-secret.yaml file which are specific to the Validated Pattern application workloads.
 
 ## Role Variables
-------------
 
 Most of the variables will be dynamically set for you in this role. Variables that we will be looking for are:
 
@@ -80,20 +77,18 @@ Most of the variables will be dynamically set for you in this role. Variables th
 | values_global: | Location of the values-global.yaml file | "{{ pattern_repo_dir }}/values-secret.yaml" |
 | kubeconfig: | Environment variable for KUBECONFIG | "{{ lookup('env', 'KUBECONFIG') }}"|
 | vault_init_file: | Init Vault file which will contain Vault tokens etc | "{{ pattern_repo_dir }}/common/pattern-vault.init"|
-| vault_ns: | Namespace for Vault | "vault"|                                     
-| vault_pod: | Name of the initial Vault pod | "vault-0"|           
+| vault_ns: | Namespace for Vault | "vault"|
+| vault_pod: | Name of the initial Vault pod | "vault-0"|
 | vault_path: | Path to the Vault secrets for the Hub | "secret/hub"|
 | debug: | Whether or not to display debug info | False |
 
-> NOTE: The role is designed to use the current *git* branch that you are working on. It is also designed to derive the variables values using your environment. 
+> NOTE: The role is designed to use the current *git* branch that you are working on. It is also designed to derive the variables values using your environment.
 
 ## Dependencies
-------------
 
 None
 
 ## Site.yaml Playbook
-------------
 
 The initial playbook can be found under ansible/site.yaml and will execute the bootstrap role.
 
@@ -110,7 +105,7 @@ To start the execution of the role execute the following:
 ```sh
 $ pwd
 /home/claudiol/work/blueprints-space/multicloud-gitops
-$ ansible-playbook ansible/site.yaml 
+$ ansible-playbook ansible/site.yaml
 ```
 
 License
@@ -120,6 +115,7 @@ BSD
 
 Author Information
 ------------------
+
 Lester Claudio (claudiol@redhat.com) <br>
 Jonathan Rickard (jrickard@redhat.com)<br>
 Michele Baldessari (mbaldess@redhat.com)<br>

--- a/ansible/roles/bootstrap/defaults/main.yml
+++ b/ansible/roles/bootstrap/defaults/main.yml
@@ -22,4 +22,4 @@ vault_pod: "vault-0"
 vault_path: "secret/hub"
 
 # To DEBUG or not to DEBUG
-debug: False
+debug: false


### PR DESCRIPTION
We disable the following linters to begin with:

  VALIDATE_BASH: false
  VALIDATE_JSCPD: false
  VALIDATE_KUBERNETES_KUBEVAL: false
  VALIDATE_YAML: false

Kubeval is already covered by us and we cannot use this one because it
does not have all of our OCP-specific schemas. JSCP needs to be disabled
because our is not yaml for the most part but helm templates which are
not recognized. Same with the YAML validator.
We can debate if we reenable shell later. In any case we should to it
only after we merge the vault utils ansible port.

Our main goal is to always have gitleaks running to be notified if a
key/password gets pushed accidentally. We can see that it is indeed
running:

  2022-06-27 15:47:57 [INFO]   ---------------------------
  2022-06-27 15:47:57 [INFO]   File:[/github/workspace/clustergroup/templates/namespaces.yaml]
  2022-06-27 15:47:57 [INFO]    - File:[namespaces.yaml] was linted with [gitleaks] successfully
  2022-06-27 15:47:57 [INFO]      - Command output:
  ------
      ○
      │╲
      │ ○
      ○ ░
      ░    gitleaks
  3:47PMINF scan completed in 404.005µs
  3:47PMINF no leaks found
