### PR TITLE
Allow unsealing of vault inside cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ help:
 	make -f common/Makefile $*
 
 install: deploy ## installs the pattern, inits the vault and loads the secrets
-	make vault-init
+	@if grep -v -e '^\s\+#' "values-hub.yaml" | grep -q -e "insecureUnsealVaultInsideCluster:\s\+true"; then \
+	  echo "Skipping 'make vault-init' as we're unsealing the vault from inside the cluster"; \
+	else \
+	  make vault-init; \
+	fi
 	make load-secrets
 	echo "Installed"
 

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -1,6 +1,9 @@
 clusterGroup:
   name: hub
   isHubCluster: true
+  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
+  # is fundamentally insecure
+  insecureUnsealVaultInsideCluster: false
 
   namespaces:
   - open-cluster-management


### PR DESCRIPTION
This is based off of https://github.com/hybrid-cloud-patterns/common/pull/103
and allows to set unsealVaultInsideCluster to true to unseal the vault via a
custom cronjob

- WIP Add job to unseal the vault from the cluster
- Add default 'unsealVaultInsideCluster: false' to values-hub.yaml
- Add roles path in top-level ansible.cfg
- Skip calling 'make vault-init' if unsealVaultInsideCluster is set to true
- Test unsealinsidecluster to true
