### PR TITLE
Make sure helm installation works on upgrade as well

### DIFF
--- a/ansible/roles/bootstrap/tasks/install-charts.yaml
+++ b/ansible/roles/bootstrap/tasks/install-charts.yaml
@@ -19,7 +19,9 @@
     chart_ref: "{{ pattern_repo_dir }}/common/install"
     release_namespace: default
     wait: true
-    replace: true
+    # Replace: false calls 'helm upgrade -i' by default. I.e. it
+    # does an install when the helm name does not exist an upgrade otherwise
+    replace: false
     force: true
     values_files:
       - "{{ globals_file }}"


### PR DESCRIPTION
Let's set replace: to false. As documented in [1]:
replace:
  Reuse the given name, only if that name is a deleted release which remains in the history.
  This is unsafe in production environment.
  mutually exclusive with with history_max.

Checking out the implementation of this module we see that with replace:
set to false it calls 'helm upgrade -i' and not 'helm install' [2].

From helm's help:

    $ helm upgrade --help |grep -- "-i, --install"
      -i, --install     if a release by this name doesn't already exist, run an install

[1] https://github.com/ansible-collections/kubernetes.core/blob/main/docs/kubernetes.core.helm_module.rst
[2] https://github.com/ansible-collections/kubernetes.core/blob/2.3.2/plugins/modules/helm.py#L414-L418
