### PR TITLE
Updating inline documentation

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -78,6 +78,8 @@ clusterGroup:
     # The default schedule is every 10 minutes: imperative.schedule
     # Total timeout of all jobs is 1h: imperative.activeDeadlineSeconds
     # imagePullPolicy is set to always: imperative.imagePullPolicy
+    # For additional overrides that apply to the jobs, please refer to
+    # https://hybrid-cloud-patterns.io/imperative-actions/#additional-job-customizations
     jobs:
     - name: regional-ca
       # ansible playbook to be run


### PR DESCRIPTION
Provided URL to upstream documentation to show what parameters are
configurable. This prevents the overloading of information within
the chart and keeps the overall deploy msg succinct.

This PR depends on https://github.com/hybrid-cloud-patterns/docs/pull/134