### PR TITLE
Comment file key in values-secret.yaml.template

### DIFF
--- a/values-secret.yaml.template
+++ b/values-secret.yaml.template
@@ -11,16 +11,16 @@ secrets:
       secret_access_key: VALUE
 
 # Required for automated spoke deployment
-files:
-  # # ssh-rsa AAA...
-  # publickey: ~/.ssh/id_rsa.pub
-  #
-  # # -----BEGIN RSA PRIVATE KEY
-  # # ...
-  # # -----END RSA PRIVATE KEY
-  # privatekey: ~/.ssh/id_rsa
-  #
-  # # {"auths":{"cloud.openshift.com":{"auth":"b3Blb... }}}
-  # openshiftPullSecret: ~/.dockerconfigjson
-  #
-  # azureOsServicePrincipal: ~/osServicePrincipal.json
+# files:
+#   # ssh-rsa AAA...
+#   publickey: ~/.ssh/id_rsa.pub
+#
+#   # -----BEGIN RSA PRIVATE KEY
+#   # ...
+#   # -----END RSA PRIVATE KEY
+#   privatekey: ~/.ssh/id_rsa
+#
+#   # {"auths":{"cloud.openshift.com":{"auth":"b3Blb... }}}
+#   openshiftPullSecret: ~/.dockerconfigjson
+#
+#   azureOsServicePrincipal: ~/osServicePrincipal.json


### PR DESCRIPTION
If `file:` is present but doesn't contain anything, the vault Ansible module will fail. By commenting it out, this allows a user to copy values-secret.yaml.template as-is and have `make install` complete successfully.