### PR TITLE
Add .gitleaks.toml

### DIFF
--- a/.github/linters/.gitleaks.toml
+++ b/.github/linters/.gitleaks.toml
@@ -2,7 +2,7 @@
 # As of v4, gitleaks only matches against filename, not path in the
 # files directive.  Leaving content for backwards compatibility.
 files = [
-  "common/ansible/plugins/modules/*.py",
-  "common/ansible/tests/unit/test_*.py",
-  "common/ansible/tests/unit/*.yaml",
+  "ansible/plugins/modules/*.py",
+  "ansible/tests/unit/test_*.py",
+  "ansible/tests/unit/*.yaml",
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,1 @@
+.github/linters/.gitleaks.toml


### PR DESCRIPTION
This adds it to .github/linters and then also symlinks to the root of
the git repository. So we are covered for the super-linter job in CI
and for the splunk cloud scanner running in our org.
