### PR TITLE
RHPDS support: Adding python3-kubernetes.noarch to dnf install

### DIFF
--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -6,7 +6,7 @@
   # from a virtualenv
   - name: Make sure make is installed
     become: true
-    ansible.builtin.command: dnf install -y make ansible
+    ansible.builtin.command: dnf install -y make ansible python3-kubernetes
     failed_when: false
 
   - name: Make sure kubernetes module is installed


### PR DESCRIPTION
This change only affect the RHPDS deployment.
Adding python3-kubernetes.noarch to dnf install