### PR TITLE
Move MCG to use a V2 values-secret.yaml.template by default

### DIFF
--- a/values-secret.yaml.template
+++ b/values-secret.yaml.template
@@ -1,26 +1,12 @@
----
+version: "2.0"
+# Ideally you NEVER COMMIT THESE VALUES TO GIT (although if all passwords are automatically generated inside
+# the vault this should not really matter)
+
 secrets:
-  # NEVER COMMIT THESE VALUES TO GIT
-  config-demo:
-    # Secret used for demonstrating vault storage, external secrets, and ACM distribution
-    secret: VALUE
-
-  # Required for automated spoke deployment
-  # aws:
-  #    access_key_id: VALUE
-  #    secret_access_key: VALUE
-
-# Required for automated spoke deployment
-files:
-  # # ssh-rsa AAA...
-  # publickey: ~/.ssh/id_rsa.pub
-  #
-  # # -----BEGIN RSA PRIVATE KEY
-  # # ...
-  # # -----END RSA PRIVATE KEY
-  # privatekey: ~/.ssh/id_rsa
-  #
-  # # {"auths":{"cloud.openshift.com":{"auth":"b3Blb... }}}
-  # openshiftPullSecret: ~/.dockerconfigjson
-  #
-  # azureOsServicePrincipal: ~/osServicePrincipal.json
+  - name: config-demo
+    vaultPrefixes:
+    - hub
+    fields:
+    - name: secret
+      onMissingValue: generate
+      vaultPolicy: validatedPatternDefaultPolicy


### PR DESCRIPTION
This template requires no copying to the home folder by default.
The password will be generated using the default VP password policy.
