### PR TITLE
Prompt ansible-vault password via ansible.builtin.pause

### DIFF
--- a/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -62,10 +62,17 @@
   ansible.builtin.set_fact:
     is_encrypted: "{{ encrypted.rc == 0 | bool }}"
 
+- name: Get password for "{{ found_file }}"
+  ansible.builtin.pause:
+    prompt: "Input the password for {{ found_file }}"
+    echo: false
+  when: is_encrypted
+  register: vault_pass
+
 - name: Get decrypted content if {{ found_file }} was encrypted
   no_log: true
-  ansible.builtin.command:
-    ansible-vault view "{{ found_file }}"
+  ansible.builtin.shell:
+    ansible-vault view --vault-password-file <(cat <<<"{{ vault_pass.user_input }}") "{{ found_file }}"
   register: values_secret_plaintext
   when: is_encrypted
 


### PR DESCRIPTION
This is triggered only when the file is detected to be encrypted.
It makes for a better UX as the prompt makes it clear for which
file we're asking the password.
