### PR TITLE
Add filter_plugin path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,4 @@ localhost_warning=False
 retry_files_enabled=False
 library=~/.ansible/plugins/modules:./ansible/plugins/modules:./common/ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=~/.ansible/roles:./ansible/roles:./common/ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+filter_plugins=~/.ansible/plugins/filter:./ansible/plugins/filter:./common/ansible/plugins/filter:/usr/share/ansible/plugins/filter


### PR DESCRIPTION
We might one day need a filter plugin in ansible. We might as well
make it so that it works out of the box already.
