### PR TITLE
Add commented out section for easier clusterpool deployment

### DIFF
--- a/values-secret.yaml.template
+++ b/values-secret.yaml.template
@@ -8,3 +8,26 @@ secrets:
     - name: secret
       onMissingValue: generate
       vaultPolicy: validatedPatternDefaultPolicy
+
+  # If you use clusterPools you will need to uncomment the following lines
+  #- name: aws
+  #  fields:
+  #  - name: aws_access_key_id
+  #    ini_file: ~/.aws/credentials
+  #    ini_section: default
+  #    ini_key: aws_access_key_id
+  #  - name: aws_secret_access_key
+  #    ini_file: ~/.aws/credentials
+  #    ini_key: aws_secret_access_key
+  #- name: publickey
+  #  fields:
+  #  - name: content
+  #    path: ~/.ssh/id_rsa.pub
+  #- name: privatekey
+  #  fields:
+  #  - name: content
+  #    path: ~/.ssh/id_rsa
+  #- name: openshiftPullSecret
+  #  fields:
+  #  - name: content
+  #    path: ~/.pullsecret.json


### PR DESCRIPTION
In order to make clusters deployed by ACM via the clusterPool
mechanism a bit simpler [1], let's add some commented out
lines that would simplify and help this.

[1] https://hybrid-cloud-patterns.io/blog/2022-10-12-acm-provisioning/
