### PR TITLE
Add trivial Hello World demo

### DIFF
--- a/charts/all/hello-world/Chart.yaml
+++ b/charts/all/hello-world/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+description: A Helm chart to show a webserver and with no other dependencies
+keywords:
+- pattern
+name: hello-world
+version: 0.0.1

--- a/charts/all/hello-world/templates/hello-world-cm.yaml
+++ b/charts/all/hello-world/templates/hello-world-cm.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-world-configmap
+  labels:
+    app.kubernetes.io/instance: hello-world
+data:
+  "index.html": |-
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <title>Hello World</title>
+        </head>
+          <body>
+            <h1>Hello World!</h1>
+            <br/>
+            <h2>
+            Hub Cluster domain is '{{ .Values.global.hubClusterDomain }}' <br>
+            Pod is running on Local Cluster Domain '{{ .Values.global.localClusterDomain }}' <br>
+            </h2>
+          </body>
+      </html>

--- a/charts/all/hello-world/templates/hello-world-deployment.yaml
+++ b/charts/all/hello-world/templates/hello-world-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      deploymentconfig: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        deploymentconfig: hello-world
+      name: hello-world
+    spec:
+      containers:
+      - name: apache
+        image: registry.access.redhat.com/ubi8/httpd-24:1-226
+        #imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: hello-world-configmap
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+      volumes:
+      - name: hello-world-configmap
+        configMap:
+          defaultMode: 438
+          name: hello-world-configmap

--- a/charts/all/hello-world/templates/hello-world-route.yaml
+++ b/charts/all/hello-world/templates/hello-world-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: hello-world
+    weight: 100
+  wildcardPolicy: None

--- a/charts/all/hello-world/templates/hello-world-svc.yaml
+++ b/charts/all/hello-world/templates/hello-world-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-world
+    deploymentconfig: hello-world
+  sessionAffinity: None
+  type: ClusterIP

--- a/charts/all/hello-world/values.yaml
+++ b/charts/all/hello-world/values.yaml
@@ -1,0 +1,4 @@
+---
+global:
+  hubClusterDomain: hub.example.com
+  localCluster: local.example.com

--- a/tests/all-hello-world-industrial-edge-factory.expected.yaml
+++ b/tests/all-hello-world-industrial-edge-factory.expected.yaml
@@ -1,0 +1,120 @@
+---
+# Source: hello-world/templates/hello-world-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-world-configmap
+  labels:
+    app.kubernetes.io/instance: hello-world
+data:
+  "index.html": |-
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <title>Hello World</title>
+        </head>
+          <body>
+            <h1>Hello World!</h1>
+            <br/>
+            <h2>
+            Hub Cluster domain is 'apps.hub.example.com' <br>
+            Pod is running on Local Cluster Domain 'apps.region.example.com' <br>
+            </h2>
+          </body>
+      </html>
+---
+# Source: hello-world/templates/hello-world-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-world
+    deploymentconfig: hello-world
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: hello-world/templates/hello-world-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      deploymentconfig: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        deploymentconfig: hello-world
+      name: hello-world
+    spec:
+      containers:
+      - name: apache
+        image: registry.access.redhat.com/ubi8/httpd-24:1-226
+        #imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: hello-world-configmap
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+      volumes:
+      - name: hello-world-configmap
+        configMap:
+          defaultMode: 438
+          name: hello-world-configmap
+---
+# Source: hello-world/templates/hello-world-route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: hello-world
+    weight: 100
+  wildcardPolicy: None

--- a/tests/all-hello-world-industrial-edge-hub.expected.yaml
+++ b/tests/all-hello-world-industrial-edge-hub.expected.yaml
@@ -1,0 +1,120 @@
+---
+# Source: hello-world/templates/hello-world-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-world-configmap
+  labels:
+    app.kubernetes.io/instance: hello-world
+data:
+  "index.html": |-
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <title>Hello World</title>
+        </head>
+          <body>
+            <h1>Hello World!</h1>
+            <br/>
+            <h2>
+            Hub Cluster domain is 'apps.hub.example.com' <br>
+            Pod is running on Local Cluster Domain 'apps.region.example.com' <br>
+            </h2>
+          </body>
+      </html>
+---
+# Source: hello-world/templates/hello-world-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-world
+    deploymentconfig: hello-world
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: hello-world/templates/hello-world-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      deploymentconfig: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        deploymentconfig: hello-world
+      name: hello-world
+    spec:
+      containers:
+      - name: apache
+        image: registry.access.redhat.com/ubi8/httpd-24:1-226
+        #imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: hello-world-configmap
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+      volumes:
+      - name: hello-world-configmap
+        configMap:
+          defaultMode: 438
+          name: hello-world-configmap
+---
+# Source: hello-world/templates/hello-world-route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: hello-world
+    weight: 100
+  wildcardPolicy: None

--- a/tests/all-hello-world-medical-diagnosis-hub.expected.yaml
+++ b/tests/all-hello-world-medical-diagnosis-hub.expected.yaml
@@ -1,0 +1,120 @@
+---
+# Source: hello-world/templates/hello-world-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-world-configmap
+  labels:
+    app.kubernetes.io/instance: hello-world
+data:
+  "index.html": |-
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <title>Hello World</title>
+        </head>
+          <body>
+            <h1>Hello World!</h1>
+            <br/>
+            <h2>
+            Hub Cluster domain is 'apps.hub.example.com' <br>
+            Pod is running on Local Cluster Domain 'apps.region.example.com' <br>
+            </h2>
+          </body>
+      </html>
+---
+# Source: hello-world/templates/hello-world-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-world
+    deploymentconfig: hello-world
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: hello-world/templates/hello-world-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      deploymentconfig: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        deploymentconfig: hello-world
+      name: hello-world
+    spec:
+      containers:
+      - name: apache
+        image: registry.access.redhat.com/ubi8/httpd-24:1-226
+        #imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: hello-world-configmap
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+      volumes:
+      - name: hello-world-configmap
+        configMap:
+          defaultMode: 438
+          name: hello-world-configmap
+---
+# Source: hello-world/templates/hello-world-route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: hello-world
+    weight: 100
+  wildcardPolicy: None

--- a/tests/all-hello-world-naked.expected.yaml
+++ b/tests/all-hello-world-naked.expected.yaml
@@ -1,0 +1,120 @@
+---
+# Source: hello-world/templates/hello-world-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-world-configmap
+  labels:
+    app.kubernetes.io/instance: hello-world
+data:
+  "index.html": |-
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <title>Hello World</title>
+        </head>
+          <body>
+            <h1>Hello World!</h1>
+            <br/>
+            <h2>
+            Hub Cluster domain is 'hub.example.com' <br>
+            Pod is running on Local Cluster Domain '' <br>
+            </h2>
+          </body>
+      </html>
+---
+# Source: hello-world/templates/hello-world-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-world
+    deploymentconfig: hello-world
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: hello-world/templates/hello-world-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      deploymentconfig: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        deploymentconfig: hello-world
+      name: hello-world
+    spec:
+      containers:
+      - name: apache
+        image: registry.access.redhat.com/ubi8/httpd-24:1-226
+        #imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: hello-world-configmap
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+      volumes:
+      - name: hello-world-configmap
+        configMap:
+          defaultMode: 438
+          name: hello-world-configmap
+---
+# Source: hello-world/templates/hello-world-route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: hello-world
+    weight: 100
+  wildcardPolicy: None

--- a/tests/all-hello-world-normal.expected.yaml
+++ b/tests/all-hello-world-normal.expected.yaml
@@ -1,0 +1,120 @@
+---
+# Source: hello-world/templates/hello-world-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-world-configmap
+  labels:
+    app.kubernetes.io/instance: hello-world
+data:
+  "index.html": |-
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <title>Hello World</title>
+        </head>
+          <body>
+            <h1>Hello World!</h1>
+            <br/>
+            <h2>
+            Hub Cluster domain is 'apps.hub.example.com' <br>
+            Pod is running on Local Cluster Domain 'apps.region.example.com' <br>
+            </h2>
+          </body>
+      </html>
+---
+# Source: hello-world/templates/hello-world-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-world
+    deploymentconfig: hello-world
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: hello-world/templates/hello-world-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      deploymentconfig: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        deploymentconfig: hello-world
+      name: hello-world
+    spec:
+      containers:
+      - name: apache
+        image: registry.access.redhat.com/ubi8/httpd-24:1-226
+        #imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/www/html
+          name: hello-world-configmap
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+      volumes:
+      - name: hello-world-configmap
+        configMap:
+          defaultMode: 438
+          name: hello-world-configmap
+---
+# Source: hello-world/templates/hello-world-route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: hello-world
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
This simple helm app is useful to demo a simple app that adds a route,
displays a helm variable and nothing else. I.e. this can work without
vault or secrets being involved.

This is useful when testing Hosted Argo stuff because the framework is
a bit more limited in capabilities in that context.

Tested it and it all worked as expected.

Note that we do not enable this by default, it's there in case but not
enabled by default like config-demo is.
