### PR TITLE
Revert "Removing channel from ACM subscription"

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -13,6 +13,7 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
+      channel: release-2.6
       #csv: advanced-cluster-management.v2.6.1
 
   projects:


### PR DESCRIPTION
This reverts commit 06a54e3a976d819ea51dd777553302dabb8ceb5b.
Seems 2.7 is the default now and has an issue or two
