### PR TITLE
Fix name of regional clusters to group-one

### DIFF
--- a/values-group-one.yaml
+++ b/values-group-one.yaml
@@ -5,7 +5,7 @@ global:
     installPlanApproval: Automatic
 
 clusterGroup:
-  name: region-one
+  name: group-one
   isHubCluster: false
 
   namespaces:


### PR DESCRIPTION
Via 8f5d2eaa94171a82ee6ddb5a918aa753265909b0 we switched to functional
grouping as opposed to regional. Let's move the name to group-one as
well. This is needed because otherwise on the remote cluster we have two
different behaviours:
1. When referenced in ACM it will be the name that is set in
   values-hub.yaml inside the managedClusterGroup
2. When referenced in gitops it will be the name set in
   values-group-one.yaml

So they need to be the same or odd discrepancies will arise.
