### PR TITLE
common automatic update

### DIFF
--- a/common/Changes.md
+++ b/common/Changes.md
@@ -1,5 +1,13 @@
 # Changes
 
+## Apr 11, 2023
+
+* Apply the ACM ocp-gitops-policy everywhere but the hub
+
+## Apr 7, 2023
+
+* Moved to gitops-1.8 channel by default (stable is unmaintained and will be dropped starting with ocp-4.13)
+
 ## March 20, 2023
 
 * Upgraded ESO to 0.8.1

--- a/common/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/common/acm/templates/policies/ocp-gitops-policy.yaml
@@ -35,7 +35,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators
@@ -76,3 +76,7 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -1,3 +1,7 @@
+main:
+  gitops:
+    channel: "gitops-1.8"
+
 global:
   pattern: none
   repoURL: none

--- a/common/tests/acm-industrial-edge-factory.expected.yaml
+++ b/common/tests/acm-industrial-edge-factory.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/common/tests/acm-industrial-edge-hub.expected.yaml
+++ b/common/tests/acm-industrial-edge-hub.expected.yaml
@@ -121,6 +121,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/common/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -112,6 +112,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -530,6 +530,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-industrial-edge-factory.expected.yaml
+++ b/tests/common-acm-industrial-edge-factory.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -121,6 +121,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -112,6 +112,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-naked.expected.yaml
+++ b/tests/common-acm-naked.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -530,6 +530,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1


### PR DESCRIPTION
- Add a change entry for gitops-1.8
- Do not apply the ocp-gitops-policy on the hub via ACM
- Do not hardcode the gitops version that gets installed on spokes
- Fix up common/ tests
