### PR TITLE
Add commented out letsencrypt support in MCG

### DIFF
--- a/values-AWS.yaml
+++ b/values-AWS.yaml
@@ -1,0 +1,26 @@
+# The following snippet can be commented out in oroder
+# to enable letsencrypt certificates on API endpoint and default
+# ingress of the cluster
+# It is currently very experimental and unsupported.
+# PLEASE read https://github.com/hybrid-cloud-patterns/common/tree/main/letsencrypt#readme
+# for all the limitations around it
+
+
+# letsencrypt:
+#   enabled: true
+#   api_endpoint: true
+#   # FIXME: tweak this to match your region
+#   region: eu-central-1
+#   server: https://acme-v02.api.letsencrypt.org/directory
+#   # server: https://acme-staging-v02.api.letsencrypt.org/directory
+#   # FIXME: set this to your correct email
+#   email: iwashere@iwashere.com
+#
+# clusterGroup:
+#   applications:
+#     letsencrypt:
+#       name: letsencrypt
+#       namespace: letsencrypt
+#       # Using 'default' as that exists everywhere
+#       project: default
+#       path: common/letsencrypt


### PR DESCRIPTION
Adding it in ./values-AWS.yaml as this is the only supported cloud atm
Put in a few comments linking the README and the chart's status

Tested on MCG hub and spoke and correctly got signed certs for all apps
on hub and spoke.
