### PR TITLE
Add the ability to tune ACM availability

### DIFF
--- a/common/acm/templates/multiclusterhub.yaml
+++ b/common/acm/templates/multiclusterhub.yaml
@@ -6,4 +6,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
+  {{- if .Values.acm }}
+  {{- if .Values.acm.availabilityConfig }}
   availabilityConfig: {{ default "High" .Values.acm.availabilityConfig }}
+  {{- end }}
+  {{- end }}

--- a/common/acm/templates/multiclusterhub.yaml
+++ b/common/acm/templates/multiclusterhub.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
+  availabilityConfig: {{ default "High" .Values.acm.availabilityConfig }}

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -8,7 +8,8 @@ global:
   targetRevision: main
 
 # acm:
-#   availabilityConfig: Basic
+#   # Can be "High" or "Basic"    
+#   availabilityConfig: High
 
 clusterGroup:
   managedClusterGroups:

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -7,6 +7,8 @@ global:
   repoURL: none
   targetRevision: main
 
+acm:
+  availabilityConfig: Basic
 
 clusterGroup:
   managedClusterGroups:

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -7,8 +7,8 @@ global:
   repoURL: none
   targetRevision: main
 
-acm:
-  availabilityConfig: Basic
+# acm:
+#   availabilityConfig: Basic
 
 clusterGroup:
   managedClusterGroups:

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -13,8 +13,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec:
-  availabilityConfig: High
+spec: {}
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -13,7 +13,8 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
+  availabilityConfig: High
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-industrial-edge-factory.expected.yaml
+++ b/tests/common-acm-industrial-edge-factory.expected.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-naked.expected.yaml
+++ b/tests/common-acm-naked.expected.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -399,7 +399,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-spec: {}
+spec:
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/common-letsencrypt-industrial-edge-factory.expected.yaml
+++ b/tests/common-letsencrypt-industrial-edge-factory.expected.yaml
@@ -1,0 +1,202 @@
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: letsencrypt
+spec:
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.region.example.com
+        servingCertificate:
+          name: api-validated-patterns-letsencrypt-cert
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  server:
+    route:
+      enabled: true
+      tls:
+         termination: reencrypt
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  managementState: "Managed"
+  unsupportedConfigOverrides:
+    # Here's an example to supply custom DNS settings.
+    controller:
+      args:
+        - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+        - "--dns01-recursive-nameservers-only"
+---
+# Source: letsencrypt/templates/api-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-validated-patterns-cert
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: api-validated-patterns-letsencrypt-cert
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: 'api.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+  - api.region.example.com
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/wildcard-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lets-encrypt-certs
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: lets-encrypt-wildcart-cert-tls
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: '*.apps.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+    - '*.apps.region.example.com'
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: validated-patterns-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: test@example.com
+    privateKeySecretRef:
+      name: validated-patterns-issuer-account-key
+    solvers:
+    - selector: {}
+      dns01:
+        route53:
+          region: eu-central-1
+          accessKeyIDSecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_access_key_id
+          secretAccessKeySecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_secret_access_key
+---
+# Source: letsencrypt/templates/credentials-request.yaml
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: letsencrypt-cert-manager-dns
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - 'route53:ChangeResourceRecordSets'
+      - 'route53:GetChange'
+      - 'route53:ListHostedZonesByName'
+      - 'route53:ListHostedZones'
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: cert-manager-dns-credentials
+    namespace: cert-manager
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  routeAdmission:
+    wildcardPolicy: WildcardsAllowed
+  defaultCertificate:
+    name: lets-encrypt-wildcart-cert-tls
+# Patch the cluster-wide argocd instance so it uses the ingress tls cert
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: "stable-v1"
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/common-letsencrypt-industrial-edge-hub.expected.yaml
+++ b/tests/common-letsencrypt-industrial-edge-hub.expected.yaml
@@ -1,0 +1,202 @@
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: letsencrypt
+spec:
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.region.example.com
+        servingCertificate:
+          name: api-validated-patterns-letsencrypt-cert
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  server:
+    route:
+      enabled: true
+      tls:
+         termination: reencrypt
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  managementState: "Managed"
+  unsupportedConfigOverrides:
+    # Here's an example to supply custom DNS settings.
+    controller:
+      args:
+        - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+        - "--dns01-recursive-nameservers-only"
+---
+# Source: letsencrypt/templates/api-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-validated-patterns-cert
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: api-validated-patterns-letsencrypt-cert
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: 'api.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+  - api.region.example.com
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/wildcard-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lets-encrypt-certs
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: lets-encrypt-wildcart-cert-tls
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: '*.apps.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+    - '*.apps.region.example.com'
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: validated-patterns-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: test@example.com
+    privateKeySecretRef:
+      name: validated-patterns-issuer-account-key
+    solvers:
+    - selector: {}
+      dns01:
+        route53:
+          region: eu-central-1
+          accessKeyIDSecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_access_key_id
+          secretAccessKeySecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_secret_access_key
+---
+# Source: letsencrypt/templates/credentials-request.yaml
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: letsencrypt-cert-manager-dns
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - 'route53:ChangeResourceRecordSets'
+      - 'route53:GetChange'
+      - 'route53:ListHostedZonesByName'
+      - 'route53:ListHostedZones'
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: cert-manager-dns-credentials
+    namespace: cert-manager
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  routeAdmission:
+    wildcardPolicy: WildcardsAllowed
+  defaultCertificate:
+    name: lets-encrypt-wildcart-cert-tls
+# Patch the cluster-wide argocd instance so it uses the ingress tls cert
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: "stable-v1"
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/common-letsencrypt-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-letsencrypt-medical-diagnosis-hub.expected.yaml
@@ -1,0 +1,202 @@
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: letsencrypt
+spec:
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.region.example.com
+        servingCertificate:
+          name: api-validated-patterns-letsencrypt-cert
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  server:
+    route:
+      enabled: true
+      tls:
+         termination: reencrypt
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  managementState: "Managed"
+  unsupportedConfigOverrides:
+    # Here's an example to supply custom DNS settings.
+    controller:
+      args:
+        - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+        - "--dns01-recursive-nameservers-only"
+---
+# Source: letsencrypt/templates/api-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-validated-patterns-cert
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: api-validated-patterns-letsencrypt-cert
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: 'api.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+  - api.region.example.com
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/wildcard-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lets-encrypt-certs
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: lets-encrypt-wildcart-cert-tls
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: '*.apps.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+    - '*.apps.region.example.com'
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: validated-patterns-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: test@example.com
+    privateKeySecretRef:
+      name: validated-patterns-issuer-account-key
+    solvers:
+    - selector: {}
+      dns01:
+        route53:
+          region: eu-central-1
+          accessKeyIDSecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_access_key_id
+          secretAccessKeySecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_secret_access_key
+---
+# Source: letsencrypt/templates/credentials-request.yaml
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: letsencrypt-cert-manager-dns
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - 'route53:ChangeResourceRecordSets'
+      - 'route53:GetChange'
+      - 'route53:ListHostedZonesByName'
+      - 'route53:ListHostedZones'
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: cert-manager-dns-credentials
+    namespace: cert-manager
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  routeAdmission:
+    wildcardPolicy: WildcardsAllowed
+  defaultCertificate:
+    name: lets-encrypt-wildcart-cert-tls
+# Patch the cluster-wide argocd instance so it uses the ingress tls cert
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: "stable-v1"
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/common-letsencrypt-naked.expected.yaml
+++ b/tests/common-letsencrypt-naked.expected.yaml
@@ -1,0 +1,202 @@
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: letsencrypt
+spec:
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.example.com
+        servingCertificate:
+          name: api-validated-patterns-letsencrypt-cert
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  server:
+    route:
+      enabled: true
+      tls:
+         termination: reencrypt
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  managementState: "Managed"
+  unsupportedConfigOverrides:
+    # Here's an example to supply custom DNS settings.
+    controller:
+      args:
+        - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+        - "--dns01-recursive-nameservers-only"
+---
+# Source: letsencrypt/templates/api-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-validated-patterns-cert
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: api-validated-patterns-letsencrypt-cert
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: 'api.example.com'
+  usages:
+    - server auth
+  dnsNames:
+  - api.example.com
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/wildcard-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lets-encrypt-certs
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: lets-encrypt-wildcart-cert-tls
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: '*.apps.example.com'
+  usages:
+    - server auth
+  dnsNames:
+    - '*.apps.example.com'
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: validated-patterns-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: test@example.com
+    privateKeySecretRef:
+      name: validated-patterns-issuer-account-key
+    solvers:
+    - selector: {}
+      dns01:
+        route53:
+          region: eu-central-1
+          accessKeyIDSecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_access_key_id
+          secretAccessKeySecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_secret_access_key
+---
+# Source: letsencrypt/templates/credentials-request.yaml
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: letsencrypt-cert-manager-dns
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - 'route53:ChangeResourceRecordSets'
+      - 'route53:GetChange'
+      - 'route53:ListHostedZonesByName'
+      - 'route53:ListHostedZones'
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: cert-manager-dns-credentials
+    namespace: cert-manager
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  routeAdmission:
+    wildcardPolicy: WildcardsAllowed
+  defaultCertificate:
+    name: lets-encrypt-wildcart-cert-tls
+# Patch the cluster-wide argocd instance so it uses the ingress tls cert
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: "stable-v1"
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/common-letsencrypt-normal.expected.yaml
+++ b/tests/common-letsencrypt-normal.expected.yaml
@@ -1,0 +1,202 @@
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+spec:
+---
+# Source: letsencrypt/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: letsencrypt
+spec:
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.region.example.com
+        servingCertificate:
+          name: api-validated-patterns-letsencrypt-cert
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  server:
+    route:
+      enabled: true
+      tls:
+         termination: reencrypt
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  managementState: "Managed"
+  unsupportedConfigOverrides:
+    # Here's an example to supply custom DNS settings.
+    controller:
+      args:
+        - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+        - "--dns01-recursive-nameservers-only"
+---
+# Source: letsencrypt/templates/api-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-validated-patterns-cert
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: api-validated-patterns-letsencrypt-cert
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: 'api.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+  - api.region.example.com
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/wildcard-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lets-encrypt-certs
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: lets-encrypt-wildcart-cert-tls
+  duration: 168h0m0s
+  renewBefore: 28h0m0s
+  commonName: '*.apps.region.example.com'
+  usages:
+    - server auth
+  dnsNames:
+    - '*.apps.region.example.com'
+  issuerRef:
+    name: validated-patterns-issuer
+    kind: ClusterIssuer
+  subject:
+    organizations:
+    - hybrid-cloud-patterns.io
+---
+# Source: letsencrypt/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: validated-patterns-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: test@example.com
+    privateKeySecretRef:
+      name: validated-patterns-issuer-account-key
+    solvers:
+    - selector: {}
+      dns01:
+        route53:
+          region: eu-central-1
+          accessKeyIDSecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_access_key_id
+          secretAccessKeySecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_secret_access_key
+---
+# Source: letsencrypt/templates/credentials-request.yaml
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: letsencrypt-cert-manager-dns
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - 'route53:ChangeResourceRecordSets'
+      - 'route53:GetChange'
+      - 'route53:ListHostedZonesByName'
+      - 'route53:ListHostedZones'
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: cert-manager-dns-credentials
+    namespace: cert-manager
+---
+# Source: letsencrypt/templates/default-routes.yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true, Validate=false, SkipDryRunOnMissingResource=true
+spec:
+  routeAdmission:
+    wildcardPolicy: WildcardsAllowed
+  defaultCertificate:
+    name: lets-encrypt-wildcart-cert-tls
+# Patch the cluster-wide argocd instance so it uses the ingress tls cert
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator
+---
+# Source: letsencrypt/templates/cert-manager-installation.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: "stable-v1"
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Consume less resources on small environments by setting `availabilityConfig` to `Basic`.