### PR TITLE
common automatic update

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -10,12 +10,6 @@ jobs:
       # Important: This sets up your GITHUB_WORKSPACE environment variable
       - uses: actions/checkout@v3
 
-      - name: Lint Ansible Playbook (common)
-        uses: ansible/ansible-lint-action@v6
-        # Let's point it to the path
-        with:
-          path: "common/ansible/"
-
       - name: Lint Ansible Playbook
         uses: ansible/ansible-lint-action@v6
         # Let's point it to the path

--- a/common/.ansible-lint
+++ b/common/.ansible-lint
@@ -6,9 +6,12 @@ skip_list:
   - template-instead-of-copy # Templated files should use template instead of copy
   - yaml[line-length] # too long lines
   - yaml[indentation] # Forcing lists to be always indented by 2 chars is silly IMO
+  - var-naming[no-role-prefix] # This would be too much churn for very little gain
+  - no-changed-when
+  - var-naming[no-role-prefix] # There are too many changes now and it would be too risky
 
 # ansible-lint gh workflow cannot find ansible.cfg hence fails to import vault_utils role
 exclude_paths:
   - ./ansible/playbooks/vault/vault.yaml
+  - ./ansible/playbooks/iib-ci/iib-ci.yaml
   - ./ansible/roles/vault_utils/tests/test.yml
-

--- a/common/Changes.md
+++ b/common/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## May 18, 2023
+
+* Introduce a EXTRA_HELM_OPTS env variable that will be passed to the helm invocations
+
 ## April 21, 2023
 
 * Added labels and annotation support to namespaces.yaml template

--- a/common/Makefile
+++ b/common/Makefile
@@ -3,8 +3,14 @@ ifneq ($(origin TARGET_SITE), undefined)
   TARGET_SITE_OPT=--set main.clusterGroupName=$(TARGET_SITE)
 endif
 
+# This variable can be set in order to pass additional helm arguments from the
+# the command line. I.e. we can set things without having to tweak values files
+EXTRA_HELM_OPTS ?=
+
 # INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:394248
-INDEX_IMAGES ?= 
+# or
+# INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:394248,registry-proxy.engineering.redhat.com/rh-osbs/iib:394249
+INDEX_IMAGES ?=
 
 TARGET_ORIGIN ?= origin
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
@@ -14,7 +20,7 @@ TARGET_REPO=$(shell git ls-remote --get-url --symref $(TARGET_ORIGIN) | sed -e '
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # --set values always take precedence over the contents of -f
-HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT)
+HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(EXTRA_HELM_OPTS)
 
 ##@ Pattern Common Tasks
 
@@ -35,7 +41,7 @@ show: ## show the starting template without installing it
 # warnings when the chart gets applied the first time, but the resources were
 # created first via the VP operator's UI
 .PHONY: operator-deploy
-operator-deploy operator-upgrade: validate-prereq validate-origin load-iibs ## runs helm install
+operator-deploy operator-upgrade: validate-prereq validate-origin ## runs helm install
 	@set -e; if ! oc get crds patterns.gitops.hybrid-cloud-patterns.io >/dev/null 2>&1; then \
 	  echo "Running helm:"; \
 	  helm upgrade --install $(NAME) common/operator-install/ $(HELM_OPTS); \
@@ -55,20 +61,11 @@ uninstall: ## runs helm uninstall
 load-secrets: ## loads the secrets into the vault
 	common/scripts/vault-utils.sh push_secrets $(NAME)
 
-b.PHONY: load-iibs
-load-iibs:
+.PHONY: load-iib
+load-iib: ## CI target to install Index Image Bundles
 	@set -e; if [ x$(INDEX_IMAGES) != x ]; then \
-		echo "Allowing insecure registries"; \
-		oc patch image.config.openshift.io/cluster --patch '{"spec":{"registrySources":{"insecureRegistries":["registry-proxy-stage.engineering.redhat.com", "registry-proxy.engineering.redhat.com"]}}}' --type=merge; \
-		for iib in $(shell echo $(INDEX_IMAGES) | tr ',' '\n'); do \
-			echo "Processing $$iib" \
-			export iibnum=$$(echo $$iib | sed 's/.*://'); \
-			rm -rf $$PWD/manifests-iib-* ;\
-			oc adm catalog mirror --manifests-only $$iib $$(dirname $$iib) --insecure; \
-			sed -i "s/name: iib$$/name: iib-$$iibnum/" $$PWD/manifests-iib-*/catalogSource.yaml ; \
-			echo "Applying $$iib manifests" \
-			oc apply -f $$PWD/manifests-iib-*/imageContentSourcePolicy.yaml ; \
-			oc apply -f $$PWD/manifests-iib-*/catalogSource.yaml ; \
+		for IIB in $(shell echo $(INDEX_IMAGES) | tr ',' '\n'); do \
+			INDEX_IMAGE="$${IIB}" ansible-playbook common/ansible/playbooks/iib-ci/iib-ci.yaml; \
 		done; \
 	fi
 

--- a/common/ansible/playbooks/iib-ci/iib-ci.yaml
+++ b/common/ansible/playbooks/iib-ci/iib-ci.yaml
@@ -1,0 +1,8 @@
+# This playbook invokes the iib_ci role
+---
+- name: IIB CI playbook
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - iib_ci

--- a/common/ansible/roles/iib_ci/README.md
+++ b/common/ansible/roles/iib_ci/README.md
@@ -1,0 +1,67 @@
+# IIB Utilities
+
+A set of ansible plays to fetch an IIB (Image Index Bundle, aka a container created by the operator sdk
+that contains a bunch of references to operators that can be installed in an OpenShift cluster)
+
+Run `make lookup` to see which IIBs are available.
+
+Typically IIB are prerelease stuff that lives on some internal boxes. What these scripts do is fetch
+the IIB internally, mirror it to the registry inside the cluster, parse all the needed images and mirror
+those to the internal cluster registry and then set up the registries.conf files on all nodes so
+that the images used are the ones pointing to the internal cluster.
+
+## Usage
+
+By default the operator to be installed from the IIB is `openshift-gitops-operator`. You can override this through the `OPERATOR` env variable.
+For example, to install openshift-gitops from an IIB on OCP 4.13 you would do the following:
+
+```sh
+export KUBECONFIG=/tmp/foo/kubeconfig
+export INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:iib-492329 
+export KUBEADMINPASS="11111-22222-33333-44444"
+# This will push the IIB and all the needed images for the default openshift-gitops-operator into the cluster
+make load-iib
+# This will install the pattern using the gitops operator from the IIB
+export CHANNEL=$(oc get -n openshift-marketplace packagemanifests -l "catalog=iib-492329" --field-selector 'metadata.name=openshift-gitops-operator' -o jsonpath='{.items[0].status.defaultChannel}')
+make EXTRA_HELM_OPTS="--set main.gitops.operatorSource=iib-492329 --set main.gitops.channel=${CHANNEL}" install
+```
+
+To install ACM from an IIB we can run the following:
+
+```sh
+export OPERATOR=advanced-cluster-management
+export KUBECONFIG=/tmp/foo/kubeconfig
+export INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:iib-499623
+export KUBEADMINPASS="11111-22222-33333-44444"
+
+make load-iib
+export CHANNEL=$(oc get -n openshift-marketplace packagemanifests -l "catalog=iib-499623" --field-selector 'metadata.name=advanced-cluster-management' -o jsonpath='{.items[0].status.defaultChannel}')
+make EXTRA_HELM_OPTS="--set main.extraParameters[0].name=clusterGroup.subscriptions.acm.source --set main.extraParameters[0].value=iib-499623 --set main.extraParameters[1].name=clusterGroup.subscriptions.acm.channel --set main.extraParameters[1].value=${CHANNEL}" install 2>&1 | tee /tmp/acm-install.log
+```
+
+*Note*: This needs VP operator version >= 0.0.14
+
+### OCP 4.13 and onwards
+
+Since 4.13 supports an internal registry that can cope with v2 docker manifests, we
+use that. Run `make iib` with the following environment variables set:
+
+* `INDEX_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/iib:492329`
+* `KUBEADMINPASS="11111-22222-33333-44444"`
+
+### OCP 4.12 and previous versions
+
+Due to the lack of v2 manifest support on the internal registry, we use an external
+registry. Run `make iib` with the following environment variables set:
+
+* `INDEX_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/iib:492329`
+* `REGISTRY=quay.io/rhn_support_mbaldess/iib`
+* `REGISTRY_TOKEN=<username>:<token>`
+
+## Useful commands
+
+* List all images uploaded to the internal registry:
+
+```sh
+oc exec -it -n openshift-image-registry $(oc get pods -n openshift-image-registry -o json | jq -r '.items[].metadata.name | select(. | test("^image-registry-"))' | head -n1) -- bash -c "curl -k -u kubeadmin:$(oc whoami -t) https://localhost:5000/v2/_catalog"
+```

--- a/common/ansible/roles/iib_ci/defaults/main.yml
+++ b/common/ansible/roles/iib_ci/defaults/main.yml
@@ -1,0 +1,17 @@
+rh_internal_registry: registry-proxy.engineering.redhat.com
+iib_image: "{{ lookup('env', 'INDEX_IMAGE') }}"
+
+external_registry: "{{ lookup('env', 'REGISTRY') }}"
+external_registry_token: "{{ lookup('env', 'REGISTRY_TOKEN') }}"
+external_registry_email: noemail@localhost
+
+kubeadminpass: "{{ lookup('env', 'KUBEADMINPASS') }}"
+
+internal_registry_ns: openshift-marketplace
+internal_registry_email: noemail@localhost
+internal_registry_user: registry-custom-user
+internal_registry_pass: "{{ lookup('env', 'INTERNAL_REGISTRY_USER') }}"
+
+# We can use default(, true) below because OPERATOR is a string and not
+# a boolean
+operator: "{{ lookup('env', 'OPERATOR') | default('openshift-gitops-operator', true) }}"

--- a/common/ansible/roles/iib_ci/handlers/main.yml
+++ b/common/ansible/roles/iib_ci/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for vault_utils

--- a/common/ansible/roles/iib_ci/meta/main.yml
+++ b/common/ansible/roles/iib_ci/meta/main.yml
@@ -1,0 +1,29 @@
+galaxy_info:
+  author: Validated Patterns Team https://github.com/hybrid-cloud-patterns/
+  description: Internal module to work with IIBs (Image Index Bundles)
+
+  issue_tracker_url: https://github.com/hybrid-cloud-patterns/common/issues
+  license: Apache-2.0
+  min_ansible_version: "2.1"
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+
+  galaxy_tags: []
+
+dependencies: []

--- a/common/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
+++ b/common/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
@@ -1,0 +1,95 @@
+# This task fetches all the images given an operator name
+# the operator name is defined in the variable "item". This
+# set of tasks is to be included in a loop that goes over the
+# needed operators
+- name: Get default channel in the IIB for "{{ item }}"
+  ansible.builtin.shell: |
+    oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ iib }}" --field-selector "metadata.name={{ item }}" \
+      -o jsonpath='{.items[0].status.defaultChannel}'
+  register: default_channel_raw
+  retries: 10
+  delay: 10
+  until: default_channel_raw is not failed
+
+- name: Set default channel fact
+  ansible.builtin.set_fact:
+    default_channel: "{{ default_channel_raw.stdout }}"
+
+- name: Get all related images in the IIB for "{{ item }}"
+  ansible.builtin.shell: |
+    oc get packagemanifests -l "catalog=iib-{{ iib }}" --field-selector "metadata.name={{ item }}" \
+      -o jsonpath="{.items[0].status.channels[?(@.name==\"{{ default_channel }}\")].currentCSVDesc.relatedImages}"
+  register: related_images_raw
+
+- name: Set related_images fact
+  ansible.builtin.set_fact:
+    related_images: "{{ related_images_raw.stdout }}"
+
+# NOTE(bandini)
+# The following code is here to fund out what the operator bundle image is and to make
+# sure it is on the internal registry.
+# This is all potentially hacky, but so far I could not find a single place in the cluster
+# where the olm.bundle image is available. The info is in there in the IIB, but it certainly
+# is not in any package manifest nor catalogsource. This is why we resort to invoking opm
+# alpha commands inside the IIB image locally
+- name: Pull the IIB locally
+  ansible.builtin.command:
+    podman pull "{{ iib_image }}"
+
+# $ opm alpha list channels /configs advanced-cluster-management
+# PACKAGE                      CHANNEL      HEAD
+# advanced-cluster-management  release-2.7  advanced-cluster-management.v2.7.4
+# advanced-cluster-management  release-2.8  advanced-cluster-management.v2.8.0-130
+- name: Read the operator bundle from the default channel
+  ansible.builtin.shell: |
+    set -o pipefail
+    podman run -it --rm "{{ iib_image }}" alpha list channels /configs "{{ item }}" | grep --word-regexp "{{ default_channel }}" | awk '{ print $3 }'
+  register: bundle_channel_raw
+
+- name: Set bundle fact
+  ansible.builtin.set_fact:
+    bundle_channel: "{{ bundle_channel_raw.stdout }}"
+
+- name: Fail if bundle_channel is empty
+  ansible.builtin.fail:
+    msg: "Failed to find bundle from channel: {{ bundle_channel_raw }}"
+  when: >
+    (bundle_channel is not defined) or (bundle_channel | length == 0)
+
+# $ opm alpha list bundles /configs advanced-cluster-management
+# PACKAGE                      CHANNEL      BUNDLE                                  REPLACES                            SKIPS  SKIP RANGE          IMAGE
+# advanced-cluster-management  release-2.7  advanced-cluster-management.v2.7.0                                                 >=2.6.0 <2.7.0      registry.stage.redhat.io/rhacm2/acm-operator-bundle@sha256:f63d0a9a0e3dc9d86e84279c50e9c613d8430e71a3821d418e168250ca3b747c
+# advanced-cluster-management  release-2.7  advanced-cluster-management.v2.7.1      advanced-cluster-management.v2.7.0         >=2.6.0 <2.7.1      registry.stage.redhat.io/rhacm2/acm-operator-bundle@sha256:a81a574f2f22d37681c44fe0c3b958074408705415de333de54d120145537533
+# advanced-cluster-management  release-2.7  advanced-cluster-management.v2.7.2      advanced-cluster-management.v2.7.1         >=2.6.0 <2.7.2      registry.stage.redhat.io/rhacm2/acm-operator-bundle@sha256:8a2c758689eaebe6a287315ca18fd9122f323e195ea3410db005b6a449060fad
+# advanced-cluster-management  release-2.7  advanced-cluster-management.v2.7.3      advanced-cluster-management.v2.7.2         >=2.6.0 <2.7.3      registry.stage.redhat.io/rhacm2/acm-operator-bundle@sha256:208f4d9473a923817c102bb7e5f138d3e1e8ed3057a23a220ffa8fe9c0c27128
+# advanced-cluster-management  release-2.7  advanced-cluster-management.v2.7.4      advanced-cluster-management.v2.7.3         >=2.6.0 <2.7.4      registry.stage.redhat.io/rhacm2/acm-operator-bundle@sha256:75b6438e08800b2e3608aeb01c1c0a68810108d9905fff35916afd21e6d32685
+# advanced-cluster-management  release-2.8  advanced-cluster-management.v2.8.0-130                                             >=2.7.0 <2.8.0-130  registry.stage.redhat.io/rhacm2/acm-operator-bundle@sha256:6c385aa69256cdd964ae9e79e52ce52e1048391f0557af59843326c4ebe9bec0
+- name: Get bundle image
+  ansible.builtin.shell: |
+    set -o pipefail
+    podman run -it --rm "{{ iib_image }}" alpha list bundles /configs "{{ item }}" | grep --word-regexp "{{ bundle_channel }}" | awk '{ print $NF }'
+  register: bundle_image_raw
+
+- name: Set bundle image fact
+  ansible.builtin.set_fact:
+    bundle_image: "{{ bundle_image_raw.stdout }}"
+
+- name: Fail if bundle_image is empty
+  ansible.builtin.fail:
+    msg: "Failed to find bundle image: {{ bundle_image_raw }}"
+  when: >
+    (bundle_image is not defined) or (bundle_image | length == 0)
+
+# all_images will be a list as follows:
+# [ "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:d5829e880db4b82a50a4962d61ea148522a93644174931b256d7ad866eadcf40",
+#   "registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:5ff915a399c1cc12d4f932652b410bf7399850934833e755267bdd409f4ce11b",
+#   "registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:81e0574159c6aaabe7125d27782a5e6e5e72383a4a0ba76b44d465f3a3098759",
+#   "registry.redhat.io/rhel8/redis-6@sha256:53598a6effeb90e4f1b005b2521beffd2fa2b0c52d0e7f2347ee2abd2577cab3",
+#   "registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:efbfb010f24894f715a50832a4b3d2cdc221f283cbbdca05e388850586e9d792",
+#   "registry.redhat.io/openshift4/ose-haproxy-router@sha256:edf7ce748b703e195220b7bd7b42fa2caa4cdfd96840445e096036a0d85f1ff2",
+#   "registry.redhat.io/openshift-gitops-1/kam-delivery-rhel8@sha256:10c5a1b6a0858a812117e6fb2b28d37617d9eb83da5e4fb647059ff740a14461",
+#   "registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:6a3eaee6a4f8cb9a35363bf4c7f83a7fa2042ae62bdaa700ecd0893dd52276f5",
+#   "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-gitops-operator-bundle@sha256:e463314596098a4e774e0dda..." ]
+- name: Set all images fact (related images + operator bundles)
+  ansible.builtin.set_fact:
+    all_images: "{{ all_images + related_images + [bundle_image] }}"

--- a/common/ansible/roles/iib_ci/tasks/install-iib-in-cluster.yml
+++ b/common/ansible/roles/iib_ci/tasks/install-iib-in-cluster.yml
@@ -1,0 +1,52 @@
+- name: Remove manifest folder "{{ iib_local_folder }}"
+  ansible.builtin.file:
+    path: "{{ iib_local_folder }}"
+    state: absent
+
+- name: Create manifest folder "{{ iib_local_folder }}"
+  ansible.builtin.file:
+    path: "{{ iib_local_folder }}"
+    state: directory
+    mode: "0755"
+
+# This generates files in /tmp/manifest-IIB:
+# - mapping.txt
+# - catalogSource.yaml
+# - imageContentSourcePolicy.yaml
+- name: Mirror catalog manifests only to "{{ iib_local_folder }}"
+  ansible.builtin.shell: |
+    oc adm catalog mirror --insecure --manifests-only --to-manifests=. \
+      "{{ iib_image }}" "{{ rh_internal_registry }}/rh-osbs" > catalog.log 2>&1
+  args:
+    chdir: "{{ iib_local_folder }}"
+
+- name: Mirror IIB to "{{ mirror_iib }}"
+  ansible.builtin.shell: |
+    oc image mirror -a "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson" \
+      "{{ iib_image }}={{ mirror_iib }}" --insecure --keep-manifest-list > iib.log 2>&1
+  args:
+    chdir: "{{ iib_local_folder }}"
+  register: oc_mirror_result
+  retries: 3
+  delay: 2
+  until: oc_mirror_result is not failed
+
+- name: Template mirrored catalogsource
+  ansible.builtin.template:
+    src: ./templates/catalogSource.yaml.j2
+    dest: "{{ iib_local_folder }}/mirrored-catalogsource.yaml"
+    mode: "0644"
+
+- name: Apply mirrored catalogsource
+  ansible.builtin.shell: |
+    oc apply -f "{{ iib_local_folder }}/mirrored-catalogsource.yaml"
+
+- name: Wait for catalogsource to show up
+  ansible.builtin.shell: |
+    oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ iib }}" --field-selector "metadata.name={{ operator }}" \
+      -o jsonpath='{.items[0].status.defaultChannel}'
+  register: oc_catalogsource_result
+  retries: 30
+  delay: 10
+  until: oc_catalogsource_result is not failed
+  changed_when: false

--- a/common/ansible/roles/iib_ci/tasks/main.yml
+++ b/common/ansible/roles/iib_ci/tasks/main.yml
@@ -1,0 +1,43 @@
+- name: Check that INDEX_IMAGE env variable is set
+  ansible.builtin.fail:
+    msg: "INDEX_IMAGE: '{{ iib_image }}' is not set"
+  failed_when:
+    (iib_image is not defined or iib_image | length == 0)
+
+- name: Set IIB fact
+  ansible.builtin.set_fact:
+    iib: "{{ iib_image.split(':')[1] }}"
+
+- name: Set IIB local folder fact
+  ansible.builtin.set_fact:
+    iib_local_folder: "/tmp/manifest-{{ iib }}"
+
+- name: Get cluster version
+  # E.g. 4.13.0-rc.6 or 4.12.16
+  ansible.builtin.shell: |
+    oc get openshiftcontrollermanager/cluster -o yaml -o jsonpath='{.status.version}'
+  register: oc_version_raw
+  changed_when: false
+
+- name: Is OCP pre OCP 4.13? (aka registry supports v2 manifests)
+  ansible.builtin.set_fact:
+    use_internal_registry: "{{ oc_version_raw.stdout is version('4.13', '>=') }}"
+
+- name: Set up internal registry (OCP >= 4.13)
+  ansible.builtin.include_tasks: setup-internal-registry.yml
+  when: use_internal_registry
+
+- name: Set up external registry (OCP < 4.13)
+  ansible.builtin.include_tasks: setup-external-registry.yml
+  when: not use_internal_registry
+
+- name: Install new IIB in cluster
+  ansible.builtin.include_tasks: install-iib-in-cluster.yml
+
+- name: Mirror all related images
+  ansible.builtin.include_tasks: mirror-related-images.yml
+
+- name: Remove pullsecrets tempfolder
+  ansible.builtin.file:
+    path: "{{ pull_secrets_tempfolder.path }}"
+    state: absent

--- a/common/ansible/roles/iib_ci/tasks/mirror-related-images.yml
+++ b/common/ansible/roles/iib_ci/tasks/mirror-related-images.yml
@@ -1,0 +1,226 @@
+# This is needed because some operators like "advanced-cluster-management"
+# install a second operator "multicluster-engine"
+- name: Set operators list
+  ansible.builtin.set_fact:
+    operator_list: "{{ [operator] + (operator == 'advanced-cluster-management') | ternary(['multicluster-engine'], []) }}"
+
+- name: Set all images to empty list
+  ansible.builtin.set_fact:
+    all_images: []
+
+- name: Fetch operator images tasks
+  ansible.builtin.include_tasks: fetch-operator-images.yml
+  loop: "{{ operator_list }}"
+
+- name: Print all_images
+  ansible.builtin.debug:
+    msg: "{{ all_images }}"
+
+# A mapping.txt file will have lines like the following. Note how the image to the right of '='
+# does have a shortened hash! :
+# registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:5ff...=registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-gitops-rhel8:8256cca6
+# registry.redhat.io/openshift4/ose-haproxy-router@sha256:edf..=registry-proxy.engineering.redhat.com/rh-osbs/openshift4-ose-haproxy-router:a636cbea
+#
+# Now what we are doing here is the following:
+# 1. For every image we get from the bundle (contained in all_images var) we check if it exists. If it does great, skip to the next image
+# 2. If the image was not found above, we take the corresponding URL on the right hand side of the '=' sign in mapping.txt
+#    except that we drop the hash that exists on the right hand-side and just use the one we were given with the image.
+#    If the image is found, great. If not we need to error out because we have no idea where we can fetch it from
+- name: Find out which images really exist by consulting mapping.txt
+  ansible.builtin.shell: |
+    set -o pipefail
+    left_sha=$(echo "{{ image }}" | sed -e 's/^.*@//')
+    right=$(grep "{{ image }}" "{{ iib_local_folder }}/mapping.txt" | cut -f2 -d=)
+    right_base=$(echo $right | sed -e 's/:.*$//' -e 's/@.*$//')
+    right_log=$(echo "${right_base}@${left_sha}" | sed -e 's/\//-/g')
+    if skopeo inspect --authfile "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson" --no-tags docker://"{{ image }}" &> /tmp/skopeo-"{{ image | regex_replace('/', '-') }}".log; then
+      echo "{{ image }}"
+    elif skopeo inspect --authfile "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson" --no-tags docker://"${right_base}@${left_sha}" &> "/tmp/skopeo-${right_log}.log"; then
+      echo "${right_base}@${left_sha}"
+    else
+      echo "ERROR: both {{ image }} and echo ${right_base}@${left_sha} could not be found"
+      exit 1
+    fi
+  register: all_existing_images
+  with_items: "{{ all_images }}"
+  loop_control:
+    loop_var: image
+
+# The dictionary below will be in the following form:
+# {
+#   "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-gitops-operator-bundle@sha256:e463314596098a4e774e0ddaed0009bfdad4d79b664e28fef219c796679ee6a0": {
+#     "source": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-gitops-operator-bundle@sha256:e463314596098a4e774e0ddaed0009bfdad4d79b664e28fef219c796679ee6a0"
+#   },
+#   "registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:81e0574159c6aaabe7125d27782a5e6e5e72383a4a0ba76b44d465f3a3098759": {
+#       "source": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-argocd-rhel8@sha256:81e0574159c6aaabe7125d27782a5e6e5e72383a4a0ba76b44d465f3a3098759"
+#   },
+#   "registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:6a3eaee6a4f8cb9a35363bf4c7f83a7fa2042ae62bdaa700ecd0893dd52276f5": {
+#       "source": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-dex-rhel8@sha256:6a3eaee6a4f8cb9a35363bf4c7f83a7fa2042ae62bdaa700ecd0893dd52276f5"
+#   },
+#   "registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:efbfb010f24894f715a50832a4b3d2cdc221f283cbbdca05e388850586e9d792": {
+#       "source": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-gitops-rhel8-operator@sha256:efbfb010f24894f715a50832a4b3d2cdc221f283cbbdca05e388850586e9d792"
+#   },
+#   "registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:5ff915a399c1cc12d4f932652b410bf7399850934833e755267bdd409f4ce11b": {
+#       "source": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-gitops-rhel8@sha256:5ff915a399c1cc12d4f932652b410bf7399850934833e755267bdd409f4ce11b"
+#   },
+#   "registry.redhat.io/openshift-gitops-1/kam-delivery-rhel8@sha256:10c5a1b6a0858a812117e6fb2b28d37617d9eb83da5e4fb647059ff740a14461": {
+#       "source": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-gitops-1-kam-delivery-rhel8@sha256:10c5a1b6a0858a812117e6fb2b28d37617d9eb83da5e4fb647059ff740a14461"
+#   },
+#   "registry.redhat.io/openshift4/ose-haproxy-router@sha256:edf7ce748b703e195220b7bd7b42fa2caa4cdfd96840445e096036a0d85f1ff2": {
+#       "source": "registry.redhat.io/openshift4/ose-haproxy-router@sha256:edf7ce748b703e195220b7bd7b42fa2caa4cdfd96840445e096036a0d85f1ff2"
+#   },
+#   "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:d5829e880db4b82a50a4962d61ea148522a93644174931b256d7ad866eadcf40": {
+#       "source": "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:d5829e880db4b82a50a4962d61ea148522a93644174931b256d7ad866eadcf40"
+#   },
+#   "registry.redhat.io/rhel8/redis-6@sha256:53598a6effeb90e4f1b005b2521beffd2fa2b0c52d0e7f2347ee2abd2577cab3": {
+#       "source": "registry.redhat.io/rhel8/redis-6@sha256:53598a6effeb90e4f1b005b2521beffd2fa2b0c52d0e7f2347ee2abd2577cab3"
+#   }
+# }
+- name: Create dict with full image name+sha -> url where we will fetch it from
+  ansible.builtin.set_fact:
+    image_urls: "{{ image_urls | default({}) | combine({item: {'source': all_existing_images.results[counter].stdout,
+      'source_nosha': all_existing_images.results[counter].stdout | regex_replace('@.*$', '')}}, recursive=true) }}"
+  loop: "{{ all_images }}"
+  loop_control:
+    index_var: counter
+
+- name: Create dict with full image name+sha -> mirror destination (OCP >= 4.13)
+  ansible.builtin.set_fact:
+    image_urls: "{{ image_urls | default({}) | combine({item:
+      {'mirrordest': mirror_dest + item | basename,
+       'mirrordest_nosha': (mirror_dest + item | basename) | regex_replace('@.*$', ''),
+       'mirrordest_tag': iib}}, recursive=true) }}"
+  loop: "{{ all_images }}"
+  when: use_internal_registry
+
+- name: Create dict with full image name+sha -> mirror destination (OCP < 4.13)
+  ansible.builtin.set_fact:
+    image_urls: "{{ image_urls | default({}) | combine({item:
+      {'mirrordest': mirror_dest + '@' + item | basename | regex_replace('^.*@', ''),
+       'mirrordest_nosha': mirror_dest,
+       'mirrordest_tag': 'tag-' + item | basename | regex_replace('^.*@sha256:', '')}}, recursive=true) }}"
+  loop: "{{ all_images }}"
+  when: not use_internal_registry
+
+- name: Create dict with full image name+sha -> image key without sha
+  ansible.builtin.set_fact:
+    image_urls: "{{ image_urls | default({}) | combine({item: {'image_nosha': item | regex_replace('@.*$', '')}}, recursive=true) }}"
+  loop: "{{ all_images }}"
+
+# At this point the dictionary looks as follows:
+# "registry.redhat.io/rhel8/redis-6@sha256:53598a6effeb90e4f1b005b2521beffd2fa2b0c52d0e7f2347ee2abd2577cab3": {
+#   "mirrordest": "default-route-openshift-image-registry.apps.mcg-hub.blueprints.rhecoeng.com/openshift-marketplace/redis-6@sha256:535...
+#   "mirrordest_nosha": "default-route-openshift-image-registry.apps.mcg-hub.blueprints.rhecoeng.com/openshift-marketplace/redis-6",
+#   "source": "registry.redhat.io/rhel8/redis-6@sha256:53598a6effeb90e4f1b005b2521beffd2fa2b0c52d0e7f2347ee2abd2577cab3",
+#   "source_nosha": "registry.redhat.io/rhel8/redis-6"
+# }
+- name: Print dict with full images
+  ansible.builtin.debug:
+    msg: "{{ image_urls }}"
+
+# OCP 4.13 uses the new fangled "ImageDigestMirrorSet", older OCPs use "ImageContentSourcePolicy"
+- name: Template out imageMirror.yaml (OCP >= 4.13)
+  ansible.builtin.template:
+    src: ./templates/imageDigestMirror.yaml.j2
+    dest: "{{ iib_local_folder }}/imageMirror.yaml"
+    mode: "0644"
+  when: use_internal_registry
+
+- name: Template out imageMirror.yaml (OCP < 4.13)
+  ansible.builtin.template:
+    src: ./templates/imageContentSourcePolicy.yaml.j2
+    dest: "{{ iib_local_folder }}/imageMirror.yaml"
+    mode: "0644"
+  when: not use_internal_registry
+
+- name: Template out mirror.map
+  ansible.builtin.template:
+    src: ./templates/mirror.map.j2
+    dest: "{{ iib_local_folder }}/mirror.map"
+    mode: "0644"
+
+# NOTE(bandini): mirror.map *must* have a tag (we use the IIB number) on the image on the right side
+# otherwise, the image will be uplaoded and will exist in S3 but it won't exist in the registry's catalog!!
+- name: Mirror all the needed images
+  ansible.builtin.shell: |
+    set -o pipefail
+    oc image mirror -a "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson" -f mirror.map --insecure --keep-manifest-list 2>&1 | tee -a image-mirror.log
+  args:
+    chdir: "{{ iib_local_folder }}"
+  retries: 5
+  delay: 2
+  register: oc_mirror
+  until: oc_mirror is not failed
+
+- name: Fetch MCP observedGeneration worker
+  ansible.builtin.shell:
+    oc get mcp/worker -o jsonpath='{.status.observedGeneration}'
+  register: worker_observed_generation_raw
+
+- name: Fetch MCP machineCount worker
+  ansible.builtin.shell:
+    oc get mcp/worker -o jsonpath='{.status.machineCount}'
+  register: worker_machinecount_raw
+
+- name: Fetch MCP observedGeneration master
+  ansible.builtin.shell:
+    oc get mcp/master -o jsonpath='{.status.observedGeneration}'
+  register: master_observed_generation_raw
+
+- name: Fetch MCP machineCount master
+  ansible.builtin.shell:
+    oc get mcp/master -o jsonpath='{.status.machineCount}'
+  register: master_machinecount_raw
+
+- name: Will the imageMirror trigger any changes
+  ansible.builtin.command:
+    oc diff -f "{{ iib_local_folder }}/imageMirror.yaml"
+  failed_when: false
+  register: oc_mirror_diff
+
+# We only run this piece if there is an actual change in the mirror digest for images
+# cannot use 'is failed' as that is always false when setting failed_when: false above
+- name: Apply imageMirror and wait for MCP to complete
+  when: oc_mirror_diff.rc != 0
+  block:
+    - name: Apply imageMirror
+      ansible.builtin.command:
+        oc apply -f "{{ iib_local_folder }}/imageMirror.yaml"
+
+    # NOTE(bandini): The reason to not fail on these two observedGeneration waiting
+    # tasks, is to make this idempotent: If the 'oc apply' above does *not* trigger
+    # any changes, the observed generation tasks will just timeout. And then we still
+    # wait to make sure that the readyworker count is correct.
+    - name: Wait for MCP new observedGeneration worker
+      ansible.builtin.shell:
+        oc get mcp/worker -o jsonpath='{.status.observedGeneration}'
+      register: worker_current_observed_generation_raw
+      retries: 10
+      delay: 20
+      until: worker_current_observed_generation_raw.stdout != worker_observed_generation_raw.stdout
+      failed_when: false
+
+    - name: Wait for MCP new observedGeneration master
+      ansible.builtin.shell:
+        oc get mcp/master -o jsonpath='{.status.observedGeneration}'
+      register: master_current_observed_generation_raw
+      retries: 10
+      delay: 20
+      until: master_current_observed_generation_raw.stdout != master_observed_generation_raw.stdout
+      failed_when: false
+
+    - name: Wait for MCP readyMachineCount to be the same as before applying the digest (worker)
+      ansible.builtin.shell:
+        oc get mcp/worker -o jsonpath='{.status.readyMachineCount}'
+      register: worker_current_ready_machinecount_raw
+      retries: 30
+      delay: 10
+      until: worker_current_ready_machinecount_raw.stdout == worker_machinecount_raw.stdout
+
+    - name: Wait for MCP readyMachineCount to be the same as before applying the digest (master)
+      ansible.builtin.shell:
+        oc get mcp/master -o jsonpath='{.status.readyMachineCount}'
+      register: master_current_ready_machinecount_raw
+      retries: 30
+      delay: 10
+      until: master_current_ready_machinecount_raw.stdout == master_machinecount_raw.stdout

--- a/common/ansible/roles/iib_ci/tasks/setup-external-registry.yml
+++ b/common/ansible/roles/iib_ci/tasks/setup-external-registry.yml
@@ -1,0 +1,45 @@
+- name: Check that we can push to the external registry
+  ansible.builtin.fail:
+    msg: "REGISTRY: '{{ external_registry }}' and REGISTRY_TOKEN: '{{ external_registry_token }}'. Both need to be set"
+  failed_when: >
+    (external_registry is not defined or external_registry | length == 0) or
+    (external_registry_token is not defined or external_registry_token | length == 0)
+
+- name: Get current cluster pull secrets
+  ansible.builtin.command:
+    oc extract secret/pull-secret -n openshift-config --to=-
+  register: pull_secrets_raw
+
+- name: Add external registry to pull secrets and set auth fact
+  ansible.builtin.set_fact:
+    pull_secrets_new: "{{ pull_secrets_raw.stdout | from_json }}"
+    external_registry_auth: "{{ external_registry_token | b64encode }}"
+
+- name: Add local registry to pull secrets
+  ansible.builtin.set_fact:
+    pull_secrets: "{{ pull_secrets_new | combine({'auths': {external_registry.split('/')[0]: {'email': external_registry_email, 'auth': external_registry_auth}}}, recursive=true) }}"
+
+- name: Get a tempfile for the pull secrets
+  ansible.builtin.tempfile:
+    state: directory
+  register: pull_secrets_tempfolder
+
+- name: Store pull secrets in tempfile
+  ansible.builtin.copy:
+    dest: "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson"
+    content: "{{ pull_secrets | to_nice_json }}"
+    mode: "0644"
+
+# We cannot store the logins back in the cluster, because quay.io would be overwritten and not have
+# access to the images openshift needs. See:
+# https://github.com/moby/moby/issues/37569
+# - name: Update pull-secret in the cluster
+#   ansible.builtin.shell: |
+#     oc set data secret/pull-secret -n openshift-config --from-file="{{ pull_secrets_tempfolder.path }}/.dockerconfigjson"
+- name: Set Mirror URL fact for external mirror IIB
+  ansible.builtin.set_fact:
+    mirror_iib: "{{ external_registry }}"
+
+- name: Set Mirror URL fact for external mirror
+  ansible.builtin.set_fact:
+    mirror_dest: "{{ external_registry }}"

--- a/common/ansible/roles/iib_ci/tasks/setup-internal-registry.yml
+++ b/common/ansible/roles/iib_ci/tasks/setup-internal-registry.yml
@@ -1,0 +1,108 @@
+- name: Check KUBEADMINPASS is set
+  ansible.builtin.fail:
+    msg: "KUBEADMINPASS: '{{ kubeadminpass }}' is not set"
+  failed_when: kubeadminpass is not defined or kubeadminpass | length == 0
+
+- name: Get kubeadmin api endpoint
+  ansible.builtin.command:
+    oc whoami --show-server=true
+  register: kubeadminapi_raw
+
+- name: Set kubeadminapi fact
+  ansible.builtin.set_fact:
+    kubeadminapi: "{{ kubeadminapi_raw.stdout }}"
+
+- name: Login via kubeadmin
+  ansible.builtin.command: |
+    oc login -u kubeadmin -p "{{ kubeadminpass }}" "{{ kubeadminapi }}"  --insecure-skip-tls-verify=true
+
+- name: Get kubeadmin token
+  ansible.builtin.command: |
+    oc whoami -t
+  register: oc_whoami_raw
+
+- name: Set kubeadmin token
+  ansible.builtin.set_fact:
+    kubeadmin_token: "{{ oc_whoami_raw.stdout }}"
+
+- name: Expose internal registry route
+  ansible.builtin.shell: |
+    oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+
+- name: Fetch internal registry route value
+  ansible.builtin.command:
+    oc registry info --public=true
+  register: registry_route_raw
+  retries: 20
+  delay: 10
+  until:
+    - registry_route_raw is not failed
+    - registry_route_raw.stdout | length > 0
+
+- name: Set route fact
+  ansible.builtin.set_fact:
+    registry_route: "{{ registry_route_raw.stdout }}"
+
+- name: Set registry allowedRegistries
+  ansible.builtin.shell: >
+    oc patch image.config.openshift.io/cluster --patch "{\"spec\":{\"registrySources\":{\"allowedRegistries\":[ \"registry.stage.redhat.io\", \"registry.access.redhat.com\", \"registry.connect.redhat.com\", \"ghcr.io\", \"gcr.io\", \"quay.io\", \"registry.redhat.io\",
+    \"registry-proxy.engineering.redhat.com\", \"image-registry.openshift-image-registry.svc:5000\", \"{{ registry_route }}\"]}}}" --type=merge
+
+- name: Set registry insecureRegistries
+  ansible.builtin.shell: >
+    oc patch image.config.openshift.io/cluster --patch "{\"spec\":{\"registrySources\":{\"insecureRegistries\":[ \"registry-proxy.engineering.redhat.com\",
+    \"image-registry.openshift-image-registry.svc:5000\", \"{{ registry_route }}\"]}}}" --type=merge
+
+- name: Get current cluster pull secrets
+  ansible.builtin.command:
+    oc extract secret/pull-secret -n openshift-config --to=-
+  register: pull_secrets_raw
+
+- name: Add local registry to pull secrets and set auth fact
+  ansible.builtin.set_fact:
+    pull_secrets_new: "{{ pull_secrets_raw.stdout | from_json }}"
+    internal_registry_auth: "{{ ('kubeadmin:' + kubeadmin_token) | b64encode }}"
+
+- name: Add local registry to pull secrets
+  ansible.builtin.set_fact:
+    pull_secrets: "{{ pull_secrets_new | combine({'auths': {registry_route: {'email': internal_registry_email, 'auth': internal_registry_auth}}}, recursive=true) }}"
+
+- name: Get a tempfile for the pull secrets
+  ansible.builtin.tempfile:
+    state: directory
+  register: pull_secrets_tempfolder
+
+- name: Store pull secrets in tempfile
+  ansible.builtin.copy:
+    dest: "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson"
+    content: "{{ pull_secrets | to_nice_json }}"
+    mode: "0644"
+
+- name: Update pull-secret in the cluster
+  ansible.builtin.shell: |
+    oc set data secret/pull-secret -n openshift-config --from-file="{{ pull_secrets_tempfolder.path }}/.dockerconfigjson"
+
+- name: Before proceeding here we need to make sure that the MCPs have all settled
+  ansible.builtin.shell: |
+    if [ $(oc get mcp/master -o jsonpath='{.status.readyMachineCount}') != $(oc get mcp/master -o jsonpath='{.status.machineCount}') ]; then
+      exit 1
+    fi
+    if [ $(oc get mcp/worker -o jsonpath='{.status.readyMachineCount}') != $(oc get mcp/worker -o jsonpath='{.status.machineCount}') ]; then
+      exit 1
+    fi
+  retries: 30
+  delay: 20
+  register: mcp_ready
+  until: mcp_ready is not failed
+
+- name: Login the internal registry with podman
+  ansible.builtin.command:
+    podman login --tls-verify=false --username unused --password "{{ kubeadmin_token }}" "https://{{ registry_route }}"
+
+- name: Set Mirror URL fact for internal mirror IIB
+  ansible.builtin.set_fact:
+    mirror_iib: "{{ registry_route }}/{{ internal_registry_ns }}/iib"
+
+- name: Set Mirror URL fact for internal mirror
+  ansible.builtin.set_fact:
+    mirror_dest: "{{ registry_route }}/{{ internal_registry_ns }}/"

--- a/common/ansible/roles/iib_ci/templates/catalogSource.yaml.j2
+++ b/common/ansible/roles/iib_ci/templates/catalogSource.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: iib-{{ iib }}
+  namespace: {{ internal_registry_ns }}
+spec:
+  image: {{ mirror_iib }}:{{ iib }}
+  sourceType: grpc
+  displayName: IIB {{ iib }}

--- a/common/ansible/roles/iib_ci/templates/htpasswd-oauth.yaml
+++ b/common/ansible/roles/iib_ci/templates/htpasswd-oauth.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: my_htpasswd_provider 
+    mappingMethod: claim 
+    type: HTPasswd
+    challenge: true
+    login: true
+    htpasswd:
+      fileData:
+        name: htpass-secret

--- a/common/ansible/roles/iib_ci/templates/imageContentSourcePolicy.yaml.j2
+++ b/common/ansible/roles/iib_ci/templates/imageContentSourcePolicy.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  labels:
+    operators.openshift.org/catalog: "true"
+  name: iib-{{ iib }}
+spec:
+  repositoryDigestMirrors:
+{% for item in image_urls.values() %}
+    - mirrors:
+        - {{ item.mirrordest_nosha }}
+      source: {{ item.source_nosha }}
+      mirrorSourcePolicy: NeverContactSource
+    - mirrors:
+        - {{ item.mirrordest_nosha }}
+      source: {{ item.image_nosha }}
+      mirrorSourcePolicy: NeverContactSource
+{% endfor %}

--- a/common/ansible/roles/iib_ci/templates/imageDigestMirror.yaml.j2
+++ b/common/ansible/roles/iib_ci/templates/imageDigestMirror.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  labels:
+    operators.openshift.org/catalog: "true"
+  name: iib-{{ iib }}
+spec:
+  imageDigestMirrors:
+{% for item in image_urls.values() %}
+    - mirrors:
+        - {{ item.mirrordest_nosha }}
+      source: {{ item.source_nosha }}
+      mirrorSourcePolicy: NeverContactSource
+    - mirrors:
+        - {{ item.mirrordest_nosha }}
+      source: {{ item.image_nosha }}
+      mirrorSourcePolicy: NeverContactSource
+{% endfor %}

--- a/common/ansible/roles/iib_ci/templates/mirror.map.j2
+++ b/common/ansible/roles/iib_ci/templates/mirror.map.j2
@@ -1,0 +1,3 @@
+{% for item in image_urls.values() %}
+{{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag }}
+{% endfor %}

--- a/common/ansible/roles/iib_ci/vars/main.yml
+++ b/common/ansible/roles/iib_ci/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for iib_ci

--- a/common/operator-install/templates/pattern.yaml
+++ b/common/operator-install/templates/pattern.yaml
@@ -10,6 +10,7 @@ spec:
     targetRevision: {{ .Values.main.git.revision }}
   gitOpsSpec:
     operatorChannel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
+    operatorSource: {{ default "redhat-operators" .Values.main.gitops.operatorSource }}
 {{- if .Values.main.extraParameters }}
   extraParameters:
 {{- range .Values.main.extraParameters }}

--- a/common/operator-install/values.yaml
+++ b/common/operator-install/values.yaml
@@ -5,5 +5,6 @@ main:
 
   gitops:
     channel: "gitops-1.8"
+    operatorSource: redhat-operators
 
   clusterGroupName: default

--- a/common/tests/operator-install-industrial-edge-factory.expected.yaml
+++ b/common/tests/operator-install-industrial-edge-factory.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-industrial-edge-hub.expected.yaml
+++ b/common/tests/operator-install-industrial-edge-hub.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/operator-install-medical-diagnosis-hub.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-naked.expected.yaml
+++ b/common/tests/operator-install-naked.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-normal.expected.yaml
+++ b/common/tests/operator-install-normal.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/common-operator-install-industrial-edge-factory.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/common-operator-install-industrial-edge-hub.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-operator-install-medical-diagnosis-hub.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-naked.expected.yaml
+++ b/tests/common-operator-install-naked.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-normal.expected.yaml
+++ b/tests/common-operator-install-normal.expected.yaml
@@ -12,6 +12,7 @@ spec:
     targetRevision: main
   gitOpsSpec:
     operatorChannel: gitops-1.8
+    operatorSource: redhat-operators
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
- Set gitOpsSpec.operatorSource
- Introduce EXTRA_HELM_OPTS
- Disable var-naming[no-role-prefix] in ansible lint
- Add new ansible role to deal with IIBs
- Simplify load-iib target
- Add templates folder
- Fix a couple of linting warnings
- Fix some super-linter complaints
- Skip the iib-ci playbook
- Drop var-naming[no-role-prefix] linter
- Allow for multiple images when calling load-iib
- Add help for load-iib
- Output index_image in make
- Output index_image in make (2)
- Set facts later in the playbook not in defaults/
- Fix how we export vars in make load-iib
- Fix how we export vars in make load-iib (2)
- Use machineCount to register the number of nodes that need to be ready
- Add helpful debug messages
- Add | on shell now that we call pipefail
- Test dropping nevercontact source
- Skip insecure tls when logging in
- Also allow gchr.io
- Revert "Test dropping nevercontact source"
- Fix typo
- Clarify instructions in the README file
- Automate the channel example
- Find out KUBEADMINAPI programmatically
- Use command instead of shell
- Do not grep for operator bundle unless it is the gitops operator
- Also whitelist ghcr.io
- Fetch the operator bundle itself in a more robust way
- Add more mirrors
- Some more work to support MCE
- Cleanup spacing
- Fix super-linter
- Move task in right folder
- Drop last mention of operator instead of item
- Fix up common/ tests
